### PR TITLE
fix: Wayland region capture under fractional scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.4]
 
 ### Fixed
-- **Wayland region capture under fractional scaling**: Fixed incorrect output dimensions and large black areas when capturing a region. The root cause was a logical/physical coordinate mismatch when converting region coordinates under fractional output scales; the implementation now uses a fractional logical scale (when available), converts coordinates using floor/ceil rounding, clamps to output boundaries, and resizes to the expected logical region size when needed.
+- **Wayland region capture under fractional scaling**: Corrected logical/physical mapping by using a fractional logical scale (when available) and floor/ceil rounding to avoid incorrect region sizes. Fixes [#9](https://github.com/shikoucore/grim-rs/issues/9), [@Jeremis70](https://github.com/Jeremis70).
 
 ## [0.1.3] - 2025-10-11
 


### PR DESCRIPTION
Fixes #9.

On compositors with fractional scaling enabled, region captures could produce incorrect dimensions and/or large black areas due to logical vs physical coordinate mismatches.

What changed

When fractional logical scaling is present, avoid protocol-level “region capture” paths that assume integer scaling.
Capture full outputs and then composite + software crop/resize to produce a correctly-mapped region image.
API

Expose [Grim::greatest_scale_for_region(region)](vscode-file://vscode-app/opt/visual-studio-code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to match grim’s “default scale selection” logic (greatest logical scale among outputs intersecting the region).
How to match grim’s default scale (optional)
If you want the most “grim-like” scale for a region capture, pick the scale first and then call the explicit *_with_scale APIs:
use grim_rs::{Box, Grim};
``` rust
fn main() -> grim_rs::Result<()> {
    let mut grim = Grim::new()?;

    let region = Box::new(0, 0, 1280, 800);

    // Pick a default scale like grim (greatest logical output scale intersecting the region)
    let scale = grim.greatest_scale_for_region(Some(region))?;

    let result = grim.capture_region_with_scale(region, scale)?;
    grim.save_png(result.data(), result.width(), result.height(), "region.png")?;

    Ok(())
}
```

Screenshots

grim-rs (before): 
<img width="1280" height="800" alt="Image" src="https://github.com/user-attachments/assets/85ea0512-051c-4a3e-b30e-35db40df5a67" />
grim-rs (after): 
<img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/349bdcb6-4b89-48d8-93c7-013f2ec84101" />
grim (reference): 
<img width="1920" height="1200" alt="Image" src="https://github.com/user-attachments/assets/f5a67a8e-1c60-4e54-8611-295c4f93da8c" />
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shikoucore/grim-rs/pull/10">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
