### PR TITLE
16 doesnt handle vertical monitors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,16 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   checks:
+    name: Checks
     runs-on: ubuntu-latest
 
     steps:
@@ -21,14 +29,17 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Format check
-        run: cargo fmt -- --check
+        run: cargo fmt --all -- --check
 
       - name: Clippy
-        run: cargo clippy --all-targets
+        run: cargo clippy --all-targets --all-features -- -D warnings
 
-      - name: Tests (headless-safe)
+      - name: Build all targets
+        run: cargo check --all-targets --all-features
+
+      - name: Headless-safe tests and example builds
         run: |
-          cargo test --lib --bins --tests --examples -- \
+          cargo test --all-features --lib --bins --tests --examples -- \
             --skip test_mock_capture \
             --skip test_scale_functionality \
             --skip test_ppm_format \
@@ -36,24 +47,4 @@ jobs:
             --skip test_to_jpeg
 
       - name: Build benches
-        run: cargo bench --no-run
-
-  strict-clippy:
-    name: Strict Clippy (non-blocking)
-    runs-on: ubuntu-latest
-    continue-on-error: true
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
-
-      - name: Cache cargo artifacts
-        uses: Swatinem/rust-cache@v2
-
-      - name: Clippy (deny warnings)
-        run: cargo clippy --all-targets -- -D warnings
+        run: cargo bench --no-run --all-features

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-todo.md
-
 # doc
 #doc/benchmarks.md
 #doc/performance.md

--- a/examples/comprehensive_demo.rs
+++ b/examples/comprehensive_demo.rs
@@ -14,11 +14,12 @@ use std::io::Write;
 
 /// Generate filename with timestamp (like grim-rs does by default)
 /// Format: YYYYMMDD_HHhMMmSSs_grim_demo.ext
-fn generate_demo_filename(extension: &str) -> String {
+fn generate_demo_filename(label: &str, extension: &str) -> String {
     let now = Local::now();
     format!(
-        "{}_grim_rs_demo.{}",
+        "{}_grim_rs_demo_{}.{}",
         now.format("%Y%m%d_%Hh%Mm%Ss"),
+        label,
         extension
     )
 }
@@ -59,7 +60,7 @@ fn main() -> Result<()> {
         result.data().len()
     );
 
-    let filename = generate_demo_filename("png");
+    let filename = generate_demo_filename("capture_all", "png");
     grim.save_png(result.data(), result.width(), result.height(), &filename)?;
     println!("Saved: {}\n", filename);
 
@@ -71,7 +72,7 @@ fn main() -> Result<()> {
         result_scaled.height()
     );
 
-    let filename = generate_demo_filename("png");
+    let filename = generate_demo_filename("capture_all_half", "png");
     grim.save_png(
         result_scaled.data(),
         result_scaled.width(),
@@ -88,7 +89,7 @@ fn main() -> Result<()> {
         result_scaled_25.height()
     );
 
-    let filename = generate_demo_filename("png");
+    let filename = generate_demo_filename("capture_all_quarter", "png");
     grim.save_png(
         result_scaled_25.data(),
         result_scaled_25.width(),
@@ -107,7 +108,7 @@ fn main() -> Result<()> {
         output_result.height()
     );
 
-    let filename = generate_demo_filename("png");
+    let filename = generate_demo_filename("output_full", "png");
     grim.save_png(
         output_result.data(),
         output_result.width(),
@@ -123,7 +124,7 @@ fn main() -> Result<()> {
         output_scaled.height()
     );
 
-    let filename = generate_demo_filename("png");
+    let filename = generate_demo_filename("output_half", "png");
     grim.save_png(
         output_scaled.data(),
         output_scaled.width(),
@@ -143,7 +144,7 @@ fn main() -> Result<()> {
         region_result.height()
     );
 
-    let filename = generate_demo_filename("png");
+    let filename = generate_demo_filename("region_full", "png");
     grim.save_png(
         region_result.data(),
         region_result.width(),
@@ -159,7 +160,7 @@ fn main() -> Result<()> {
         region_scaled.height()
     );
 
-    let filename = generate_demo_filename("png");
+    let filename = generate_demo_filename("region_scaled", "png");
     grim.save_png(
         region_scaled.data(),
         region_scaled.width(),
@@ -172,15 +173,16 @@ fn main() -> Result<()> {
         println!("Capturing Multiple Outputs with Different Parameters");
 
         let params = vec![
-            CaptureParameters::new(outputs[0].name()).scale(1.0),
-            CaptureParameters::new(outputs[1].name()).scale(0.5),
+            CaptureParameters::new(outputs[0].name()).overlay_cursor(true),
+            CaptureParameters::new(outputs[1].name()).region(Box::new(0, 0, 400, 300)),
         ];
 
         let multi_result = grim.capture_outputs(params)?;
         println!("Captured {} outputs", multi_result.outputs().len());
 
-        for (_output_name, capture) in multi_result.outputs().iter() {
-            let filename = generate_demo_filename("png");
+        for (output_name, capture) in multi_result.outputs().iter() {
+            let filename =
+                generate_demo_filename(&format!("multi_{}", output_name.to_lowercase()), "png");
             grim.save_png(capture.data(), capture.width(), capture.height(), &filename)?;
             println!(
                 "Saved: {} ({}x{})",
@@ -199,7 +201,7 @@ fn main() -> Result<()> {
     let format_result = grim.capture_region(format_region)?;
 
     // PNG with default compression
-    let filename_png = generate_demo_filename("png");
+    let filename_png = generate_demo_filename("format_png_default", "png");
     grim.save_png(
         format_result.data(),
         format_result.width(),
@@ -209,7 +211,7 @@ fn main() -> Result<()> {
     println!("Saved PNG (default compression): {}", filename_png);
 
     // PNG with high compression (compression level 0-9)
-    let filename_png_compressed = generate_demo_filename("png");
+    let filename_png_compressed = generate_demo_filename("format_png_best", "png");
     grim.save_png_with_compression(
         format_result.data(),
         format_result.width(),
@@ -220,7 +222,7 @@ fn main() -> Result<()> {
     println!("Saved PNG (best compression): {}", filename_png_compressed);
 
     // PPM format (uncompressed)
-    let filename_ppm = generate_demo_filename("ppm");
+    let filename_ppm = generate_demo_filename("format_ppm", "ppm");
     grim.save_ppm(
         format_result.data(),
         format_result.width(),
@@ -232,7 +234,7 @@ fn main() -> Result<()> {
     // JPEG format (if feature enabled)
     #[cfg(feature = "jpeg")]
     {
-        let filename_jpeg = generate_demo_filename("jpg");
+        let filename_jpeg = generate_demo_filename("format_jpeg_default", "jpg");
         grim.save_jpeg(
             format_result.data(),
             format_result.width(),
@@ -241,7 +243,7 @@ fn main() -> Result<()> {
         )?;
         println!("Saved JPEG (default quality): {}", filename_jpeg);
 
-        let filename_jpeg_hq = generate_demo_filename("jpg");
+        let filename_jpeg_hq = generate_demo_filename("format_jpeg_q95", "jpg");
         grim.save_jpeg_with_quality(
             format_result.data(),
             format_result.width(),
@@ -295,7 +297,7 @@ fn main() -> Result<()> {
         println!("JPEG bytes (quality 90): {} bytes", jpeg_hq_bytes.len());
     }
 
-    let filename = generate_demo_filename("png");
+    let filename = generate_demo_filename("bytes_png", "png");
     let mut file = File::create(&filename)?;
     file.write_all(&png_bytes)?;
     println!("Saved PNG from bytes: {}\n", filename);
@@ -316,7 +318,7 @@ fn main() -> Result<()> {
             span_result.height()
         );
 
-        let filename = generate_demo_filename("png");
+        let filename = generate_demo_filename("span_region", "png");
         grim.save_png(
             span_result.data(),
             span_result.width(),
@@ -331,8 +333,8 @@ fn main() -> Result<()> {
     let test_region = Box::new(0, 0, 640, 480);
     let test_result = grim.capture_region(test_region)?;
 
-    let filename_png = generate_demo_filename("png");
-    let filename_ppm = generate_demo_filename("ppm");
+    let filename_png = generate_demo_filename("compare_png", "png");
+    let filename_ppm = generate_demo_filename("compare_ppm", "ppm");
 
     grim.save_png(
         test_result.data(),
@@ -360,7 +362,7 @@ fn main() -> Result<()> {
 
     #[cfg(feature = "jpeg")]
     {
-        let filename_jpg = generate_demo_filename("jpg");
+        let filename_jpg = generate_demo_filename("compare_jpeg", "jpg");
         grim.save_jpeg(
             test_result.data(),
             test_result.width(),

--- a/src/wayland_capture/capture.rs
+++ b/src/wayland_capture/capture.rs
@@ -272,32 +272,14 @@ impl WaylandCapture {
                 } else {
                     info.scale as f64
                 };
-
-                // Convert logical coords to physical pixels. For fractional scale, we need to
-                // be careful with rounding so we don't miss edge pixels.
-                let local_x = (intersection.x() - info.logical_x) as f64;
-                let local_y = (intersection.y() - info.logical_y) as f64;
-                let local_w = intersection.width() as f64;
-                let local_h = intersection.height() as f64;
-
-                let x0 = (local_x * scale).floor() as i32;
-                let y0 = (local_y * scale).floor() as i32;
-                let x1 = ((local_x + local_w) * scale).ceil() as i32;
-                let y1 = ((local_y + local_h) * scale).ceil() as i32;
-
-                // Clamp to output boundaries in physical pixels.
-                let x0 = x0.clamp(0, info.width);
-                let y0 = y0.clamp(0, info.height);
-                let x1 = x1.clamp(0, info.width);
-                let y1 = y1.clamp(0, info.height);
-
-                if x1 <= x0 || y1 <= y0 {
-                    continue;
-                }
-
-                let physical_local_region = Box::new(x0, y0, x1 - x0, y1 - y0);
+                let local_region = Box::new(
+                    intersection.x() - info.logical_x,
+                    intersection.y() - info.logical_y,
+                    intersection.width(),
+                    intersection.height(),
+                );
                 let mut capture =
-                    self.capture_region_for_output(output, physical_local_region, overlay_cursor)?;
+                    self.capture_region_for_output(output, local_region, overlay_cursor)?;
 
                 if scale != 1.0 {
                     capture = self.scale_image_data(capture, 1.0 / scale)?;
@@ -399,7 +381,7 @@ impl WaylandCapture {
             .find(|(_, info)| info.name == output_name)
             .ok_or_else(|| Error::OutputNotFound(output_name.to_string()))?;
 
-        let local_region = Box::new(0, 0, info.width, info.height);
+        let local_region = Box::new(0, 0, info.logical_width, info.logical_height);
         self.capture_region_for_output(&output_handle, local_region, false)
     }
 
@@ -427,9 +409,7 @@ impl WaylandCapture {
         &mut self,
         parameters: Vec<CaptureParameters>,
     ) -> Result<MultiOutputCaptureResult> {
-        if self.globals.outputs.is_empty() {
-            return Err(Error::NoOutputs);
-        }
+        self.refresh_outputs()?;
 
         let screencopy_manager =
             self.globals
@@ -458,10 +438,10 @@ impl WaylandCapture {
                 .find(|o| o.id().protocol_id() == *output_id)
                 .ok_or_else(|| Error::OutputNotFound(param.output_name().to_string()))?;
             let region = if let Some(region) = param.region_ref() {
-                let output_right = output_info.x + output_info.width;
-                let output_bottom = output_info.y + output_info.height;
-                if region.x() < output_info.x
-                    || region.y() < output_info.y
+                let output_right = output_info.logical_width;
+                let output_bottom = output_info.logical_height;
+                if region.x() < 0
+                    || region.y() < 0
                     || region.x() + region.width() > output_right
                     || region.y() + region.height() > output_bottom
                 {
@@ -471,12 +451,7 @@ impl WaylandCapture {
                 }
                 *region
             } else {
-                Box::new(
-                    output_info.x,
-                    output_info.y,
-                    output_info.width,
-                    output_info.height,
-                )
+                Box::new(0, 0, output_info.logical_width, output_info.logical_height)
             };
             let frame_state = Arc::new(Mutex::new(FrameState {
                 buffer: None,
@@ -632,12 +607,50 @@ impl WaylandCapture {
             };
             let mut buffer_data = mmap.to_vec();
             convert_shm_to_rgba(&mut buffer_data, format);
+            let mut final_data = buffer_data;
+            let mut final_width = width;
+            let mut final_height = height;
+
+            if let Some(info) = self
+                .globals
+                .output_info
+                .values()
+                .find(|info| info.name == output_name)
+            {
+                if !matches!(
+                    info.transform,
+                    wayland_client::protocol::wl_output::Transform::Normal
+                ) {
+                    let (transformed_data, new_width, new_height) = apply_image_transform(
+                        &final_data,
+                        final_width,
+                        final_height,
+                        info.transform,
+                    );
+                    final_data = transformed_data;
+                    final_width = new_width;
+                    final_height = new_height;
+                }
+            }
+
+            let flags = {
+                let state = lock_frame_state(frame_state)?;
+                state.flags
+            };
+
+            if (flags & ZWLR_SCREENCOPY_FRAME_V1_FLAGS_Y_INVERT) != 0 {
+                let (inverted_data, inv_width, inv_height) =
+                    flip_vertical(&final_data, final_width, final_height);
+                final_data = inverted_data;
+                final_width = inv_width;
+                final_height = inv_height;
+            }
             results.insert(
                 output_name,
                 CaptureResult {
-                    data: buffer_data,
-                    width,
-                    height,
+                    data: final_data,
+                    width: final_width,
+                    height: final_height,
                 },
             );
         }

--- a/src/wayland_capture/wayland_events.rs
+++ b/src/wayland_capture/wayland_events.rs
@@ -349,10 +349,10 @@ impl Dispatch<ZxdgOutputV1, ()> for WaylandCapture {
                         info.logical_scale_known = true;
                         update_logical_scale(info);
                     }
-                    Event::Name { name } => {
-                        if info.name.starts_with("output-") || info.name.is_empty() {
-                            info.name = name.clone();
-                        }
+                    Event::Name { name }
+                        if info.name.starts_with("output-") || info.name.is_empty() =>
+                    {
+                        info.name = name.clone();
                     }
                     Event::Description { description } => {
                         info.description = Some(description);

--- a/tests/test_rotated_output_semantics.rs
+++ b/tests/test_rotated_output_semantics.rs
@@ -1,0 +1,41 @@
+use grim_rs::Box;
+
+#[test]
+fn rotated_output_full_capture_uses_logical_dimensions() {
+    let logical_region = Box::new(0, 0, 1080, 1920);
+    let old_physical_region = Box::new(0, 0, 1920, 1080);
+
+    assert_eq!(logical_region.width(), 1080);
+    assert_eq!(logical_region.height(), 1920);
+    assert_ne!(logical_region, old_physical_region);
+}
+
+#[test]
+fn rotated_output_multi_capture_defaults_to_local_logical_origin() {
+    let local_logical_region = Box::new(0, 0, 1080, 1920);
+    let old_global_physical_region = Box::new(3440, 0, 1920, 1080);
+
+    assert_eq!(local_logical_region, Box::new(0, 0, 1080, 1920));
+    assert_eq!(old_global_physical_region, Box::new(3440, 0, 1920, 1080));
+    assert_ne!(local_logical_region, old_global_physical_region);
+}
+
+#[test]
+fn rotated_output_region_requests_stay_in_logical_space_even_with_scale() {
+    let output_box = Box::new(3440, 0, 1080, 1920);
+    let region = Box::new(3300, 0, 300, 1400);
+    let intersection = output_box.intersection(&region).unwrap();
+
+    let requested_region = Box::new(
+        intersection.x() - output_box.x(),
+        intersection.y() - output_box.y(),
+        intersection.width(),
+        intersection.height(),
+    );
+
+    let old_physical_region = Box::new(0, 0, 320, 2160);
+
+    assert_eq!(requested_region, Box::new(0, 0, 160, 1400));
+    assert_eq!(old_physical_region, Box::new(0, 0, 320, 2160));
+    assert_ne!(requested_region, old_physical_region);
+}


### PR DESCRIPTION
The main issue was that grim-rs mixed logical, physical, and global coordinates when building screencopy regions. That worked for regular horizontal outputs, but broke full-output and region capture on rotated monitors
___


<details>
  <summary>Screenshot</summary>
  <img width="4520" height="1920" alt="check-all" src="https://github.com/user-attachments/assets/1682dc51-86da-440a-9474-976dd298eb09" />
  <img width="1080" height="1920" alt="check-dp2" src="https://github.com/user-attachments/assets/e1b316ba-d1bc-4878-ba96-f7678c6aa7fb" />
  <img width="3440" height="1440" alt="check-dp1" src="https://github.com/user-attachments/assets/54cd591f-adea-4092-83a0-566344e11022" />
</details>