### PR TITLE
cumulative update 0.1.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,12 @@ jobs:
             --skip test_scale_functionality \
             --skip test_ppm_format \
             --skip test_to_png \
-            --skip test_to_jpeg
+            --skip test_to_jpeg \
+            --skip test_new_ext_constructor \
+            --skip test_new_wlr_constructor \
+            --skip test_new_auto_is_equivalent_to_new \
+            --skip test_new_ext_can_capture \
+            --skip test_new_wlr_can_capture
 
       - name: Build benches
         run: cargo bench --no-run --all-features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.9]
 
+### Changed
+
+- **`Box` renamed to `Region`**: The geometry struct `Box` has been renamed to `Region` to eliminate the name collision with `std::boxed::Box`. This is a breaking change — all imports must change from `use grim_rs::Box` (or `use grim_rs::geometry::Box`) to `use grim_rs::Region`. The migration is a simple find-and-replace: `Box::new(` → `Region::new(`, `: Box` → `: Region`. See [MIGRATION.md](MIGRATION.md) for full details.
+
 ### Fixed
 
 - **dmabuf frame delivery for `zwlr_screencopy`**: Completed the `LinuxDmabuf` event handler so frames delivered via dmabuf (instead of `wl_shm`) are correctly processed. Captures no longer time out on compositors that prefer dmabuf — the handler populates frame dimensions and format, and the existing shm-buffer path performs the cross-device copy transparently. When a compositor sends both `Buffer` and `LinuxDmabuf` events, the `Buffer` format takes precedence to avoid mismatches.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.9]
+
+### Fixed
+
+- **dmabuf frame delivery for `zwlr_screencopy`**: Completed the `LinuxDmabuf` event handler so frames delivered via dmabuf (instead of `wl_shm`) are correctly processed. Captures no longer time out on compositors that prefer dmabuf — the handler populates frame dimensions and format, and the existing shm-buffer path performs the cross-device copy transparently. When a compositor sends both `Buffer` and `LinuxDmabuf` events, the `Buffer` format takes precedence to avoid mismatches.
+
 ## [0.1.8] 2026-05-14
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.9]
 
+### Added
+
+- **`ext-image-copy-capture-v1` backend**: New capture protocol supported alongside the existing `wlr-screencopy`. Auto-detection prefers `ext-image-copy-capture-v1` when available (Sway ≥ 2025, Hyprland, COSMIC), falling back to `wlr-screencopy`. New constructors: `Grim::new_ext()` and `Grim::new_wlr()` to force a specific backend. `Grim::new()` continues to work with auto-detection. Public `Backend` enum exposed: `Auto`, `ExtImageCopyCapture`, `WlrScreencopy`. See [library examples — Backend selection](doc/library_examples.md#backend-selection) for usage.
+
 ### Changed
 
 - **`Box` renamed to `Region`**: The geometry struct `Box` has been renamed to `Region` to eliminate the name collision with `std::boxed::Box`. This is a breaking change — all imports must change from `use grim_rs::Box` (or `use grim_rs::geometry::Box`) to `use grim_rs::Region`. The migration is a simple find-and-replace: `Box::new(` → `Region::new(`, `: Box` → `: Region`. See [MIGRATION.md](MIGRATION.md) for full details.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **`ext-image-copy-capture-v1` backend**: New capture protocol supported alongside the existing `wlr-screencopy`. Auto-detection prefers `ext-image-copy-capture-v1` when available (Sway ≥ 2025, Hyprland, COSMIC), falling back to `wlr-screencopy`. New constructors: `Grim::new_ext()` and `Grim::new_wlr()` to force a specific backend. `Grim::new()` continues to work with auto-detection. Public `Backend` enum exposed: `Auto`, `ExtImageCopyCapture`, `WlrScreencopy`. See [library examples — Backend selection](doc/library_examples.md#backend-selection) for usage.
+- **`pixel_format` module**: Public pixel format conversion utilities with `PixelFormat` enum (`Argb8888`, `Xrgb8888`, `Abgr8888`, `Xbgr8888`), `fourcc_to_format()` for DRM fourcc mapping, and `convert_to_rgba()` for in-place byte swizzle. Fully tested (9 tests). No Wayland dependency — usable for any RGBA pixel processing.
 
 ### Changed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ how we work and what is required for contributions to be accepted.
 
 ## Project Scope
 
-- grim-rs targets Wayland compositors that support `zwlr_screencopy_manager_v1`.
+- grim-rs targets Wayland compositors that support `ext-image-copy-capture-v1` or `zwlr_screencopy_manager_v1`.
 - The library is Rust-first and aims for a clean public API with minimal
   dependencies and predictable behavior.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ jpeg-encoder = { version = "0.7.0", optional = true }
 png = { version = "0.17.0", optional = true }
 thiserror = "2.0.18"
 wayland-client = "0.31"
-wayland-protocols = { version = "0.32", features = ["client", "unstable"] }
+wayland-protocols = { version = "0.32", features = ["client", "unstable", "staging"] }
 wayland-protocols-wlr = { version = "0.3", features = ["client"] }
 memmap2 = "0.9.9"
 tempfile = "3.24.0"

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,3 +1,56 @@
+# Migration Guide: 0.1.8 → 0.1.9
+
+This guide helps you upgrade from grim-rs version 0.1.8 to 0.1.9.
+
+Version 0.1.9 **renames `Box` to `Region`** to avoid name collision with `std::boxed::Box`.
+
+---
+
+## Renamed: `Box` → `Region`
+
+The `Box` struct has been renamed to `Region`. This is a **breaking change** — the old name is no longer available.
+
+### Why
+
+`use grim_rs::Box` conflicts with `std::boxed::Box`, forcing every user to write `use grim_rs::Box as GrimBox`. The new name `Region` better describes what the type represents (a rectangular region with position and size) and eliminates the collision.
+
+### Migration
+
+**Before (0.1.8):**
+```rust
+use grim_rs::Box;
+
+let region = Box::new(100, 200, 800, 600);
+let parsed: Box = "0,0 1920x1080".parse().unwrap();
+```
+
+**After (0.1.9):**
+```rust
+use grim_rs::Region;
+
+let region = Region::new(100, 200, 800, 600);
+let parsed: Region = "0,0 1920x1080".parse().unwrap();
+```
+
+### Automated migration
+
+```bash
+# Replace in your project (from grim-rs 0.1.8 to 0.1.9)
+find . -name '*.rs' -exec sed -i 's/\bBox\b/Region/g; s/\bRegion<dyn\b/Box<dyn/g' {} +
+```
+
+The second substitution preserves `Box<dyn Error>` and other `Box<dyn ...>` usages.
+
+### Full type path
+
+If you use the full path:
+```diff
+- use grim_rs::geometry::Box;
++ use grim_rs::geometry::Region;
+```
+
+---
+
 # Migration Guide: 0.1.7 → 0.1.8
 
 This guide helps you upgrade from grim-rs version 0.1.7 to 0.1.8.

--- a/README.md
+++ b/README.md
@@ -3,10 +3,15 @@
 [![Crates.io Version](https://img.shields.io/crates/v/grim-rs.svg)](https://crates.io/crates/grim-rs)
 
 > [!IMPORTANT]
-> **Breaking changes in 0.1.9:** `Box` renamed to `Region`. Read [MIGRATION.md](MIGRATION.md) **before** upgrading — the migration is straightforward but must be applied.
+> **Breaking changes in 0.1.9:**
+
+### Version 0.1.9
+### Read the documents carefully
+
+[CHANGELOG.md](CHANGELOG.md), [MIGRATION.md](MIGRATION.md) ,[Library Examples](/doc/library_examples.md), [API](doc/api.md)
 
 > if you like this project, then the best way to express gratitude is to give it a star ⭐, it doesn't cost you anything, but I understand that I'm moving the project in the right direction.
-
+___
 Rust implementation of `grim-rs` screenshot utility for Wayland compositors.
 
 > See [CHANGELOG.md](CHANGELOG.md) for version changes.
@@ -15,7 +20,7 @@ Rust implementation of `grim-rs` screenshot utility for Wayland compositors.
 ## Features
 
 - Pure Rust implementation
-- Native Wayland capture via `wl_shm` + `zwlr_screencopy_manager_v1`
+- Native Wayland capture via `ext-image-copy-capture-v1` or `zwlr_screencopy_manager_v1` with auto-detection
 - Multi-output capture and compositing
 - Full output transform handling (all 8 Wayland transform modes)
 - Adaptive image scaling (Nearest / Triangle / CatmullRom / Lanczos3)
@@ -84,7 +89,9 @@ grim-rs -o DP-1 -c monitor.png
 ### Supported Wayland Protocols
 
 - `wl_shm` - Shared memory buffers
-- `zwlr_screencopy_manager_v1` - Screenshot capture (wlroots extension)
+- `ext-image-copy-capture-v1` - Screenshot capture (new standard protocol)
+- `zwlr_screencopy_manager_v1` - Screenshot capture (wlroots extension, fallback)
+- `ext-output-image-capture-source-manager-v1` - Output capture sources
 - `wl_output` - Output information
 
 ## API Reference
@@ -96,7 +103,7 @@ Use:
 
 At a glance:
 
-- Initialize: `Grim::new()`
+- Initialize: `Grim::new()` (auto), `Grim::new_ext()`, `Grim::new_wlr()`
 - Capture: `capture_all*`, `capture_output*`, `capture_region*`, `capture_outputs*`
 - Encode/save: `save_png*`, `save_jpeg*`, `to_png*`, `to_jpeg*`
 - Stdout/stderr helpers: `write_png_to_stdout*`, `write_jpeg_to_stdout*`
@@ -169,10 +176,11 @@ Priority order: `GRIM_DEFAULT_DIR` → `XDG_PICTURES_DIR` (if it exists) → cur
 - ✅ Wayfire
 - ✅ Niri
 - ✅ Any wlroots-based compositor with `zwlr_screencopy_manager_v1`
+- ✅ Compositors with `ext-image-copy-capture-v1` (Sway ≥ 2025, Hyprland, COSMIC)
 
 ## Limitations
 
-- Requires compositor with `zwlr_screencopy_manager_v1` protocol support
+- Requires compositor with `ext-image-copy-capture-v1` or `zwlr_screencopy_manager_v1` protocol support
 - Linux-only (due to shared memory implementation)
 - Cursor overlay depends on compositor support
 
@@ -194,6 +202,7 @@ cargo test --all-targets
 cargo run --example comprehensive_demo
 cargo run --example profile_test
 cargo run --example second_monitor_demo
+cargo run --example capture_screenshots
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Use:
 At a glance:
 
 - Initialize: `Grim::new()` (auto), `Grim::new_ext()`, `Grim::new_wlr()`
+- Pixel formats: `pixel_format::PixelFormat`, `fourcc_to_format()`, `convert_to_rgba()`
 - Capture: `capture_all*`, `capture_output*`, `capture_region*`, `capture_outputs*`
 - Encode/save: `save_png*`, `save_jpeg*`, `to_png*`, `to_jpeg*`
 - Stdout/stderr helpers: `write_png_to_stdout*`, `write_jpeg_to_stdout*`
@@ -131,9 +132,10 @@ cargo doc --open
 2. **CaptureResult** - Contains screenshot data and dimensions
 3. **CaptureParameters** - Parameters for multi-output capture
 4. **Buffer** - Shared memory buffer management
-5. **Region** - Region and coordinate handling
-6. **Output** - Monitor information with transform support
-7. **Error** - Comprehensive error handling
+5. **PixelFormat** - Pixel format conversion utilities
+6. **Region** - Region and coordinate handling
+7. **Output** - Monitor information with transform support
+8. **Error** - Comprehensive error handling
 
 ### Image Processing Pipeline
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 [![Crates.io Version](https://img.shields.io/crates/v/grim-rs.svg)](https://crates.io/crates/grim-rs)
 
+> [!IMPORTANT]
+> **Breaking changes in 0.1.9:** `Box` renamed to `Region`. Read [MIGRATION.md](MIGRATION.md) **before** upgrading — the migration is straightforward but must be applied.
+
 > if you like this project, then the best way to express gratitude is to give it a star ⭐, it doesn't cost you anything, but I understand that I'm moving the project in the right direction.
 
 Rust implementation of `grim-rs` screenshot utility for Wayland compositors.
@@ -121,7 +124,7 @@ cargo doc --open
 2. **CaptureResult** - Contains screenshot data and dimensions
 3. **CaptureParameters** - Parameters for multi-output capture
 4. **Buffer** - Shared memory buffer management
-5. **Box** - Region and coordinate handling
+5. **Region** - Region and coordinate handling
 6. **Output** - Monitor information with transform support
 7. **Error** - Comprehensive error handling
 

--- a/benches/alloc_profiler.rs
+++ b/benches/alloc_profiler.rs
@@ -1,5 +1,5 @@
 use dhat::{Alloc, Profiler};
-use grim_rs::{Box as GrimBox, CaptureParameters, Grim};
+use grim_rs::{CaptureParameters, Grim, Region};
 use std::env;
 use std::fs;
 use std::process::Command;
@@ -127,7 +127,7 @@ fn run_case(kind: &str, width: u32, height: u32, out_file: &str) -> grim_rs::Res
                 None => return Ok(()),
             };
             let geom = first.geometry();
-            let region = GrimBox::new(
+            let region = Region::new(
                 geom.x() + geom.width() / 4,
                 geom.y() + geom.height() / 4,
                 (geom.width() / 2).max(1),
@@ -143,7 +143,7 @@ fn run_case(kind: &str, width: u32, height: u32, out_file: &str) -> grim_rs::Res
                 None => return Ok(()),
             };
             let geom = first.geometry();
-            let region = GrimBox::new(
+            let region = Region::new(
                 geom.x() + geom.width() / 4,
                 geom.y() + geom.height() / 4,
                 (geom.width() / 2).max(1),

--- a/benches/capture_benchmarks.rs
+++ b/benches/capture_benchmarks.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
-use grim_rs::{Box as GrimBox, CaptureParameters, Grim};
+use grim_rs::{CaptureParameters, Grim, Region};
 
 fn benchmark_capture_all(c: &mut Criterion) {
     let mut group = c.benchmark_group("capture_all");
@@ -37,9 +37,9 @@ fn benchmark_capture_region(c: &mut Criterion) {
     let mut group = c.benchmark_group("capture_region");
 
     let regions = [
-        ("small_100x100", GrimBox::new(0, 0, 100, 100)),
-        ("medium_500x500", GrimBox::new(0, 0, 500, 500)),
-        ("large_1920x1080", GrimBox::new(0, 0, 1920, 1080)),
+        ("small_100x100", Region::new(0, 0, 100, 100)),
+        ("medium_500x500", Region::new(0, 0, 500, 500)),
+        ("large_1920x1080", Region::new(0, 0, 1920, 1080)),
     ];
 
     for (name, region) in regions.iter() {
@@ -65,7 +65,7 @@ fn benchmark_capture_region_with_scale(c: &mut Criterion) {
         None => return,
     };
     let geom = output.geometry();
-    let region = GrimBox::new(
+    let region = Region::new(
         geom.x() + geom.width() / 4,
         geom.y() + geom.height() / 4,
         (geom.width() / 2).max(1),
@@ -149,7 +149,7 @@ fn benchmark_capture_outputs(c: &mut Criterion) {
                 params = params.overlay_cursor(true);
             }
             let geom = output.geometry();
-            let region = GrimBox::new(0, 0, (geom.width() / 2).max(1), (geom.height() / 2).max(1));
+            let region = Region::new(0, 0, (geom.width() / 2).max(1), (geom.height() / 2).max(1));
             params.region(region)
         })
         .collect();
@@ -178,7 +178,7 @@ fn benchmark_capture_outputs_with_scale(c: &mut Criterion) {
         .iter()
         .map(|output| {
             let geom = output.geometry();
-            let region = GrimBox::new(0, 0, (geom.width() / 2).max(1), (geom.height() / 2).max(1));
+            let region = Region::new(0, 0, (geom.width() / 2).max(1), (geom.height() / 2).max(1));
             CaptureParameters::new(output.name()).region(region)
         })
         .collect();

--- a/doc/api.md
+++ b/doc/api.md
@@ -95,6 +95,25 @@ For full rustdoc details, see [docs.rs/grim-rs](https://docs.rs/grim-rs).
 - Utilities: `is_empty()`, `intersects(...)`, `intersection(...)`
 - Parse from string: `"x,y widthxheight"`
 
+### `pixel_format` Module
+
+Public pixel format conversion utilities, independent of Wayland types.
+
+- `PixelFormat` enum — `Argb8888`, `Xrgb8888`, `Abgr8888`, `Xbgr8888`
+- `fourcc_to_format(fourcc: u32) -> Option<PixelFormat>` — map DRM fourcc to PixelFormat
+- `convert_to_rgba(data: &mut [u8], format: PixelFormat)` — in-place byte swizzle to RGBA
+
+```rust
+use grim_rs::pixel_format::{self, PixelFormat};
+
+let mut pixels = get_raw_frame();
+pixel_format::convert_to_rgba(&mut pixels, PixelFormat::Argb8888);
+
+if let Some(fmt) = pixel_format::fourcc_to_format(0x34325241) {
+    pixel_format::convert_to_rgba(&mut pixels, fmt);
+}
+```
+
 ## Feature Flags
 
 - **`jpeg`** - Enable JPEG support (enabled by default)

--- a/doc/api.md
+++ b/doc/api.md
@@ -19,8 +19,8 @@ For full rustdoc details, see [docs.rs/grim-rs](https://docs.rs/grim-rs).
 - `capture_all_with_scale(scale: f64)` - Capture entire screen with scaling
 - `capture_output(output_name: &str)` - Capture specific output by name
 - `capture_output_with_scale(output_name: &str, scale: f64)` - Capture output with scaling
-- `capture_region(region: Box)` - Capture specific rectangular region
-- `capture_region_with_scale(region: Box, scale: f64)` - Capture region with scaling
+- `capture_region(region: Region)` - Capture specific rectangular region
+- `capture_region_with_scale(region: Region, scale: f64)` - Capture region with scaling
 - `capture_outputs(parameters: Vec<CaptureParameters>)` - Capture multiple outputs with different parameters
 - `capture_outputs_with_scale(parameters: Vec<CaptureParameters>, default_scale: f64)` - Capture multiple outputs with scaling
 
@@ -78,14 +78,14 @@ For full rustdoc details, see [docs.rs/grim-rs](https://docs.rs/grim-rs).
 
 - Fields are private
 - `name()` - Output name (e.g., `eDP-1`, `HDMI-A-1`)
-- `geometry()` - Output position and size (`Box`)
+- `geometry()` - Output position and size (`Region`)
 - `scale()` - Output scale factor
 - `description()` - Optional monitor description
 
-### `Box`
+### `Region`
 
 - Fields are private
-- `Box::new(x, y, width, height)` - Create region
+- `Region::new(x, y, width, height)` - Create region
 - Accessors: `x()`, `y()`, `width()`, `height()`
 - Utilities: `is_empty()`, `intersects(...)`, `intersection(...)`
 - Parse from string: `"x,y widthxheight"`

--- a/doc/api.md
+++ b/doc/api.md
@@ -3,11 +3,16 @@
 This is a practical API index for the public surface.
 For full rustdoc details, see [docs.rs/grim-rs](https://docs.rs/grim-rs).
 
+> an example of usage is shown in [library examples](/doc/library_examples.md)
+
 ## Core Methods
 
 ### Initialization
 
-- `Grim::new()` - Create new Grim instance and connect to Wayland compositor
+- `Grim::new()` - Create new Grim instance with auto-detected backend (prefers `ext-image-copy-capture-v1`, falls back to `wlr-screencopy`)
+- `Grim::new_ext()` - Force `ext-image-copy-capture-v1` backend (fails if compositor doesn't support it)
+- `Grim::new_wlr()` - Force `wlr-screencopy` backend (fails if compositor doesn't support it)
+- `Backend` enum — `Auto`, `ExtImageCopyCapture`, `WlrScreencopy`
 
 ### Getting Display Information
 

--- a/doc/library_examples.md
+++ b/doc/library_examples.md
@@ -179,3 +179,19 @@ fn main() -> grim_rs::Result<()> {
     Ok(())
 }
 ```
+
+## Pixel format conversion
+
+```rust,no_run
+use grim_rs::pixel_format::{self, PixelFormat};
+
+fn process_raw_frame(mut data: Vec<u8>) -> Vec<u8> {
+    // Convert from ARGB8888 (DRM_FORMAT_ARGB8888) to RGBA
+    pixel_format::convert_to_rgba(&mut data, PixelFormat::Argb8888);
+    data
+}
+
+fn detect_format(fourcc: u32) -> Option<PixelFormat> {
+    pixel_format::fourcc_to_format(fourcc)
+}
+```

--- a/doc/library_examples.md
+++ b/doc/library_examples.md
@@ -10,7 +10,7 @@ Prerequisites:
 ## Basic capture operations
 
 ```rust,no_run
-use grim_rs::{Box, Grim};
+use grim_rs::{Region, Grim};
 
 fn main() -> grim_rs::Result<()> {
     let mut grim = Grim::new()?;
@@ -18,7 +18,7 @@ fn main() -> grim_rs::Result<()> {
     let result = grim.capture_all()?;
     grim.save_png(result.data(), result.width(), result.height(), "screenshot.png")?;
 
-    let region = Box::new(100, 100, 800, 600);
+    let region = Region::new(100, 100, 800, 600);
     let result = grim.capture_region(region)?;
     grim.save_png(result.data(), result.width(), result.height(), "region.png")?;
 
@@ -63,7 +63,7 @@ fn main() -> grim_rs::Result<()> {
 ## Capture with scaling
 
 ```rust,no_run
-use grim_rs::{Box, Grim};
+use grim_rs::{Region, Grim};
 
 fn main() -> grim_rs::Result<()> {
     let mut grim = Grim::new()?;
@@ -71,7 +71,7 @@ fn main() -> grim_rs::Result<()> {
     let result = grim.capture_all_with_scale(0.5)?;
     grim.save_png(result.data(), result.width(), result.height(), "thumbnail.png")?;
 
-    let region = Box::new(0, 0, 1920, 1080);
+    let region = Region::new(0, 0, 1920, 1080);
     let result = grim.capture_region_with_scale(region, 0.8)?;
     grim.save_png(result.data(), result.width(), result.height(), "scaled.png")?;
 
@@ -85,14 +85,14 @@ fn main() -> grim_rs::Result<()> {
 ## Multiple outputs
 
 ```rust,no_run
-use grim_rs::{Box, CaptureParameters, Grim};
+use grim_rs::{Region, CaptureParameters, Grim};
 
 fn main() -> grim_rs::Result<()> {
     let mut grim = Grim::new()?;
 
     let parameters = vec![
         CaptureParameters::new("DP-1").overlay_cursor(true),
-        CaptureParameters::new("HDMI-A-1").region(Box::new(0, 0, 1920, 1080)),
+        CaptureParameters::new("HDMI-A-1").region(Region::new(0, 0, 1920, 1080)),
     ];
 
     let results = grim.capture_outputs_with_scale(parameters, 0.5)?;

--- a/doc/library_examples.md
+++ b/doc/library_examples.md
@@ -7,6 +7,30 @@ Prerequisites:
 - Run inside a Wayland session.
 - Use output names returned by `grim.get_outputs()` (examples use placeholders like `DP-1`).
 
+## Backend selection
+
+`Grim::new()` auto-detects the best available capture protocol (`ext-image-copy-capture-v1` preferred, `wlr-screencopy` fallback). You can force a specific backend:
+
+- `Grim::new_ext()` — force `ext-image-copy-capture-v1` (Sway ≥2025, Hyprland, COSMIC)
+- `Grim::new_wlr()` — force `wlr-screencopy` (older Sway, River, Wayfire)
+- `Backend` enum — `Auto`, `ExtImageCopyCapture`, `WlrScreencopy`
+
+```rust,no_run
+use grim_rs::{Backend, Grim};
+
+fn main() -> grim_rs::Result<()> {
+    // Auto-detect — works everywhere
+    let mut grim = Grim::new()?;
+    // Force new protocol (Sway ≥2025, Hyprland, COSMIC)
+    let mut grim = Grim::new_ext()?;
+    // Force legacy protocol (older compositors)
+    let mut grim = Grim::new_wlr()?;
+    let result = grim.capture_all()?;
+    grim.save_png(result.data(), result.width(), result.height(), "screenshot.png")?;
+    Ok(())
+}
+```
+
 ## Basic capture operations
 
 ```rust,no_run
@@ -14,17 +38,13 @@ use grim_rs::{Region, Grim};
 
 fn main() -> grim_rs::Result<()> {
     let mut grim = Grim::new()?;
-
     let result = grim.capture_all()?;
     grim.save_png(result.data(), result.width(), result.height(), "screenshot.png")?;
-
     let region = Region::new(100, 100, 800, 600);
     let result = grim.capture_region(region)?;
     grim.save_png(result.data(), result.width(), result.height(), "region.png")?;
-
     let result = grim.capture_output("DP-1")?;
     grim.save_png(result.data(), result.width(), result.height(), "output.png")?;
-
     Ok(())
 }
 ```
@@ -37,7 +57,6 @@ use grim_rs::Grim;
 fn main() -> grim_rs::Result<()> {
     let mut grim = Grim::new()?;
     let outputs = grim.get_outputs()?;
-
     for output in outputs {
         println!("Output: {}", output.name());
         println!(
@@ -55,7 +74,6 @@ fn main() -> grim_rs::Result<()> {
             println!("  Description: {}", desc);
         }
     }
-
     Ok(())
 }
 ```
@@ -67,17 +85,13 @@ use grim_rs::{Region, Grim};
 
 fn main() -> grim_rs::Result<()> {
     let mut grim = Grim::new()?;
-
     let result = grim.capture_all_with_scale(0.5)?;
     grim.save_png(result.data(), result.width(), result.height(), "thumbnail.png")?;
-
     let region = Region::new(0, 0, 1920, 1080);
     let result = grim.capture_region_with_scale(region, 0.8)?;
     grim.save_png(result.data(), result.width(), result.height(), "scaled.png")?;
-
     let result = grim.capture_output_with_scale("DP-1", 0.5)?;
     grim.save_png(result.data(), result.width(), result.height(), "output_scaled.png")?;
-
     Ok(())
 }
 ```
@@ -89,18 +103,15 @@ use grim_rs::{Region, CaptureParameters, Grim};
 
 fn main() -> grim_rs::Result<()> {
     let mut grim = Grim::new()?;
-
     let parameters = vec![
         CaptureParameters::new("DP-1").overlay_cursor(true),
         CaptureParameters::new("HDMI-A-1").region(Region::new(0, 0, 1920, 1080)),
     ];
-
     let results = grim.capture_outputs_with_scale(parameters, 0.5)?;
     for (output_name, result) in results.into_outputs() {
         let filename = format!("{}.png", output_name);
         grim.save_png(result.data(), result.width(), result.height(), &filename)?;
     }
-
     Ok(())
 }
 ```
@@ -113,12 +124,10 @@ use grim_rs::Grim;
 fn main() -> grim_rs::Result<()> {
     let mut grim = Grim::new()?;
     let result = grim.capture_all()?;
-
     grim.save_png(result.data(), result.width(), result.height(), "screenshot.png")?;
     grim.save_png_with_compression(result.data(), result.width(), result.height(), "compressed.png", 9)?;
     grim.save_jpeg(result.data(), result.width(), result.height(), "screenshot.jpg")?;
     grim.save_jpeg_with_quality(result.data(), result.width(), result.height(), "quality.jpg", 95)?;
-
     Ok(())
 }
 ```
@@ -131,17 +140,12 @@ use grim_rs::Grim;
 fn main() -> grim_rs::Result<()> {
     let mut grim = Grim::new()?;
     let result = grim.capture_all()?;
-
     let png_bytes = grim.to_png(result.data(), result.width(), result.height())?;
     println!("PNG size: {} bytes", png_bytes.len());
-
     let _png_bytes = grim.to_png_with_compression(result.data(), result.width(), result.height(), 9)?;
-
     let jpeg_bytes = grim.to_jpeg(result.data(), result.width(), result.height())?;
     println!("JPEG size: {} bytes", jpeg_bytes.len());
-
     let _jpeg_bytes = grim.to_jpeg_with_quality(result.data(), result.width(), result.height(), 85)?;
-
     Ok(())
 }
 ```
@@ -154,12 +158,10 @@ use grim_rs::Grim;
 fn main() -> grim_rs::Result<()> {
     let mut grim = Grim::new()?;
     let result = grim.capture_all()?;
-
     grim.write_png_to_stdout(result.data(), result.width(), result.height())?;
     grim.write_png_to_stdout_with_compression(result.data(), result.width(), result.height(), 6)?;
     grim.write_jpeg_to_stdout(result.data(), result.width(), result.height())?;
     grim.write_jpeg_to_stdout_with_quality(result.data(), result.width(), result.height(), 90)?;
-
     Ok(())
 }
 ```

--- a/examples/capture_screenshots.rs
+++ b/examples/capture_screenshots.rs
@@ -1,0 +1,85 @@
+//! Capture screenshots using `ext-image-copy-capture-v1` — the new Wayland
+//! screenshot protocol.
+//!
+//! Uses `Grim::new_ext()` to force the new protocol. Fails on compositors
+//! that don't support it (KDE, GNOME, old Sway).
+//!
+//! Usage:
+//!   cargo run --example capture_screenshots
+//!
+//! All screenshots are saved to the `examples/` directory.
+
+use chrono::Local;
+use grim_rs::{CaptureParameters, Grim, Region, Result};
+
+fn filename(label: &str, ext: &str) -> String {
+    let ts = Local::now().format("%Y%m%d_%H%M%S");
+    format!("examples/{}_{}.{}", ts, label, ext)
+}
+
+fn main() -> Result<()> {
+    env_logger::init();
+    let mut grim = Grim::new_ext()?;
+    let outputs = grim.get_outputs()?;
+    println!("Outputs: {}", outputs.len());
+    for o in &outputs {
+        println!(
+            "  {} — {}x{} at ({},{}), scale={}",
+            o.name(),
+            o.geometry().width(),
+            o.geometry().height(),
+            o.geometry().x(),
+            o.geometry().y(),
+            o.scale()
+        );
+    }
+    // Full screen
+    let r = grim.capture_all()?;
+    let f = filename("full", "png");
+    grim.save_png(r.data(), r.width(), r.height(), &f)?;
+    println!("[1] full screen  — {}x{} → {}", r.width(), r.height(), f);
+    // Each output individually
+    for o in &outputs {
+        let r = grim.capture_output(o.name())?;
+        let f = filename(&format!("output_{}", o.name()), "png");
+        grim.save_png(r.data(), r.width(), r.height(), &f)?;
+        println!(
+            "[2] output {} — {}x{} → {}",
+            o.name(),
+            r.width(),
+            r.height(),
+            f
+        );
+    }
+    // Region
+    let region = Region::new(0, 0, 800, 600);
+    let r = grim.capture_region(region)?;
+    let f = filename("region_800x600", "png");
+    grim.save_png(r.data(), r.width(), r.height(), &f)?;
+    println!("[3] region 800x600 — {}x{} → {}", r.width(), r.height(), f);
+    // With cursor overlay
+    if let Some(first) = outputs.first() {
+        let params = CaptureParameters::new(first.name()).overlay_cursor(true);
+        let multi = grim.capture_outputs(vec![params])?;
+        if let Some(r) = multi.get(first.name()) {
+            let f = filename("cursor", "png");
+            grim.save_png(r.data(), r.width(), r.height(), &f)?;
+            println!("[4] cursor — {}x{} → {}", r.width(), r.height(), f);
+        }
+    }
+    // Half scale
+    let r = grim.capture_all_with_scale(0.5)?;
+    let f = filename("halfscale", "png");
+    grim.save_png(r.data(), r.width(), r.height(), &f)?;
+    println!("[5] half scale — {}x{} → {}", r.width(), r.height(), f);
+    // JPEG
+    #[cfg(feature = "jpeg")]
+    {
+        let r = grim.capture_all()?;
+        let f = filename("full", "jpg");
+        grim.save_jpeg(r.data(), r.width(), r.height(), &f)?;
+        println!("[6] JPEG — {}x{} → {}", r.width(), r.height(), f);
+    }
+    println!("Done.");
+    Ok(())
+}

--- a/examples/comprehensive_demo.rs
+++ b/examples/comprehensive_demo.rs
@@ -8,7 +8,7 @@ use chrono::Local;
 ///     cargo run --example comprehensive_demo
 ///
 /// All screenshots will be saved to the project root directory.
-use grim_rs::{Box, CaptureParameters, Grim, Result};
+use grim_rs::{CaptureParameters, Grim, Region, Result};
 use std::fs::File;
 use std::io::Write;
 
@@ -134,7 +134,7 @@ fn main() -> Result<()> {
     println!("Saved: {}\n", filename);
 
     // Capture 800x600 region starting at (100, 100)
-    let region = Box::new(100, 100, 800, 600);
+    let region = Region::new(100, 100, 800, 600);
     println!("Region: {}", region);
 
     let region_result = grim.capture_region(region)?;
@@ -174,7 +174,7 @@ fn main() -> Result<()> {
 
         let params = vec![
             CaptureParameters::new(outputs[0].name()).overlay_cursor(true),
-            CaptureParameters::new(outputs[1].name()).region(Box::new(0, 0, 400, 300)),
+            CaptureParameters::new(outputs[1].name()).region(Region::new(0, 0, 400, 300)),
         ];
 
         let multi_result = grim.capture_outputs(params)?;
@@ -197,7 +197,7 @@ fn main() -> Result<()> {
     }
 
     // Capture a small region for format tests
-    let format_region = Box::new(0, 0, 400, 300);
+    let format_region = Region::new(0, 0, 400, 300);
     let format_result = grim.capture_region(format_region)?;
 
     // PNG with default compression
@@ -249,7 +249,7 @@ fn main() -> Result<()> {
     }
     println!();
 
-    let small_region = Box::new(0, 0, 200, 150);
+    let small_region = Region::new(0, 0, 200, 150);
     let small_result = grim.capture_region(small_region)?;
 
     // Convert to PNG bytes
@@ -289,7 +289,7 @@ fn main() -> Result<()> {
 
         let span_x = output1.x() + output1.width() - 200;
         let span_width = 400;
-        let span_region = Box::new(span_x, output1.y(), span_width, 400);
+        let span_region = Region::new(span_x, output1.y(), span_width, 400);
 
         println!("Spanning region: {}", span_region);
 
@@ -312,7 +312,7 @@ fn main() -> Result<()> {
         println!("Skipping spanning region (only 1 output available)\n");
     }
 
-    let test_region = Box::new(0, 0, 640, 480);
+    let test_region = Region::new(0, 0, 640, 480);
     let test_result = grim.capture_region(test_region)?;
 
     let filename_png = generate_demo_filename("compare_png", "png");

--- a/examples/profile_test.rs
+++ b/examples/profile_test.rs
@@ -102,9 +102,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("8. Region capture (different sizes):");
     let regions = [
-        ("Small (100x100)", grim_rs::Box::new(0, 0, 100, 100)),
-        ("Medium (500x500)", grim_rs::Box::new(0, 0, 500, 500)),
-        ("Large (1920x1080)", grim_rs::Box::new(0, 0, 1920, 1080)),
+        ("Small (100x100)", grim_rs::Region::new(0, 0, 100, 100)),
+        ("Medium (500x500)", grim_rs::Region::new(0, 0, 500, 500)),
+        ("Large (1920x1080)", grim_rs::Region::new(0, 0, 1920, 1080)),
     ];
 
     for (name, region) in &regions {

--- a/examples/second_monitor_demo.rs
+++ b/examples/second_monitor_demo.rs
@@ -1,5 +1,5 @@
 use chrono::Local;
-use grim_rs::{Box, Grim, Result};
+use grim_rs::{Grim, Region, Result};
 
 fn generate_filename(description: &str, extension: &str) -> String {
     let now = Local::now();
@@ -104,7 +104,7 @@ fn main() -> Result<()> {
     let geom = second_output.geometry();
 
     println!("- Top-left corner (400x300)...");
-    let region = Box::new(
+    let region = Region::new(
         geom.x(),
         geom.y(),
         (400).min(geom.width()),
@@ -119,7 +119,7 @@ fn main() -> Result<()> {
     println!("- Center region (800x600)...");
     let center_width = (800).min(geom.width());
     let center_height = (600).min(geom.height());
-    let region = Box::new(
+    let region = Region::new(
         geom.x() + (geom.width() - center_width) / 2,
         geom.y() + (geom.height() - center_height) / 2,
         center_width,
@@ -134,7 +134,7 @@ fn main() -> Result<()> {
     println!("- Bottom-right corner (400x300)...");
     let corner_width = (400).min(geom.width());
     let corner_height = (300).min(geom.height());
-    let region = Box::new(
+    let region = Region::new(
         geom.x() + geom.width() - corner_width,
         geom.y() + geom.height() - corner_height,
         corner_width,
@@ -183,7 +183,7 @@ fn main() -> Result<()> {
     println!("- Center region at 0.75x scale...");
     let center_width = (800).min(geom.width());
     let center_height = (600).min(geom.height());
-    let region = Box::new(
+    let region = Region::new(
         geom.x() + (geom.width() - center_width) / 2,
         geom.y() + (geom.height() - center_height) / 2,
         center_width,
@@ -196,7 +196,7 @@ fn main() -> Result<()> {
     println!("Saved: {}\n", filename);
     println!("Capturing horizontal strip from second monitor...");
     let strip_height = (200).min(geom.height());
-    let region = Box::new(
+    let region = Region::new(
         geom.x(),
         geom.y() + (geom.height() - strip_height) / 2,
         geom.width(),
@@ -209,7 +209,7 @@ fn main() -> Result<()> {
     println!("Saved: {}\n", filename);
     println!("Capturing vertical strip from second monitor...");
     let strip_width = (200).min(geom.width());
-    let region = Box::new(
+    let region = Region::new(
         geom.x() + (geom.width() - strip_width) / 2,
         geom.y(),
         strip_width,
@@ -239,7 +239,7 @@ fn main() -> Result<()> {
 
     for row in 0..grid_size {
         for col in 0..grid_size {
-            let region = Box::new(
+            let region = Region::new(
                 geom.x() + col * cell_width,
                 geom.y() + row * cell_height,
                 cell_width,

--- a/src/bin/grim.rs
+++ b/src/bin/grim.rs
@@ -1,4 +1,4 @@
-use grim_rs::{Box as GrimBox, CaptureParameters, Grim};
+use grim_rs::{CaptureParameters, Grim, Region};
 use std::env;
 use std::fs;
 use std::io::{self, BufRead};
@@ -162,7 +162,7 @@ fn main() -> grim_rs::Result<()> {
 #[derive(Debug)]
 struct Options {
     scale: Option<f64>,
-    geometry: Option<GrimBox>,
+    geometry: Option<Region>,
     filetype: FileType,
     jpeg_quality: u8,
     png_level: u8,

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -1,14 +1,14 @@
 use std::fmt;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct Box {
+pub struct Region {
     x: i32,
     y: i32,
     width: i32,
     height: i32,
 }
 
-impl Box {
+impl Region {
     pub fn new(x: i32, y: i32, width: i32, height: i32) -> Self {
         Self {
             x,
@@ -38,7 +38,7 @@ impl Box {
         self.width <= 0 || self.height <= 0
     }
 
-    pub fn intersects(&self, other: &Box) -> bool {
+    pub fn intersects(&self, other: &Region) -> bool {
         if self.is_empty() || other.is_empty() {
             return false;
         }
@@ -51,7 +51,7 @@ impl Box {
         x2 > x1 && y2 > y1
     }
 
-    pub fn intersection(&self, other: &Box) -> Option<Box> {
+    pub fn intersection(&self, other: &Region) -> Option<Region> {
         if !self.intersects(other) {
             return None;
         }
@@ -61,17 +61,17 @@ impl Box {
         let x2 = (self.x + self.width).min(other.x + other.width);
         let y2 = (self.y + self.height).min(other.y + other.height);
 
-        Some(Box::new(x1, y1, x2 - x1, y2 - y1))
+        Some(Region::new(x1, y1, x2 - x1, y2 - y1))
     }
 }
 
-impl fmt::Display for Box {
+impl fmt::Display for Region {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{},{} {}x{}", self.x, self.y, self.width, self.height)
     }
 }
 
-impl std::str::FromStr for Box {
+impl std::str::FromStr for Region {
     type Err = crate::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -100,6 +100,6 @@ impl std::str::FromStr for Box {
             .parse()
             .map_err(|_| crate::Error::InvalidGeometry(s.to_string()))?;
 
-        Ok(Box::new(x, y, width, height))
+        Ok(Region::new(x, y, width, height))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ pub mod geometry;
 mod wayland_capture;
 
 pub use error::{Error, Result};
-pub use geometry::Box;
+pub use geometry::Region;
 
 use wayland_capture::WaylandCapture as PlatformCapture;
 
@@ -88,7 +88,7 @@ pub struct Output {
     /// Name of the output (e.g., "eDP-1", "HDMI-A-1").
     name: String,
     /// Geometry of the output (position and size).
-    geometry: Box,
+    geometry: Region,
     /// Scale factor of the output (e.g., 1 for normal DPI, 2 for HiDPI).
     scale: i32,
     /// Description of the output (e.g., monitor model, manufacturer info).
@@ -100,7 +100,7 @@ impl Output {
         &self.name
     }
 
-    pub fn geometry(&self) -> &Box {
+    pub fn geometry(&self) -> &Region {
         &self.geometry
     }
 
@@ -131,7 +131,7 @@ pub struct CaptureParameters {
     /// If `Some(region)`, only the specified region will be captured.
     ///
     /// The region must be within the bounds of the output.
-    region: Option<Box>,
+    region: Option<Region>,
     /// Whether to include the cursor in the capture.
     ///
     /// If `true`, the cursor will be included in the screenshot.
@@ -160,7 +160,7 @@ impl CaptureParameters {
     }
 
     /// Sets the region to capture within the output.
-    pub fn region(mut self, region: Box) -> Self {
+    pub fn region(mut self, region: Region) -> Self {
         self.region = Some(region);
         self
     }
@@ -183,7 +183,7 @@ impl CaptureParameters {
     }
 
     /// Returns the region, if set.
-    pub fn region_ref(&self) -> Option<&Box> {
+    pub fn region_ref(&self) -> Option<&Region> {
         self.region.as_ref()
     }
 
@@ -430,7 +430,7 @@ impl Grim {
     ///
     /// # Arguments
     ///
-    /// * `region` - The region to capture, specified as a [`Box`]
+    /// * `region` - The region to capture, specified as a [`Region`]
     ///
     /// # Errors
     ///
@@ -442,16 +442,16 @@ impl Grim {
     /// # Example
     ///
     /// ```rust,no_run
-    /// use grim_rs::{Grim, Box};
+    /// use grim_rs::{Grim, Region};
     ///
     /// let mut grim = Grim::new()?;
     /// // x=100, y=100, width=800, height=600
-    /// let region = Box::new(100, 100, 800, 600);
+    /// let region = Region::new(100, 100, 800, 600);
     /// let result = grim.capture_region(region)?;
     /// println!("Captured region: {}x{}", result.width(), result.height());
     /// # Ok::<(), grim_rs::Error>(())
     /// ```
-    pub fn capture_region(&mut self, region: Box) -> Result<CaptureResult> {
+    pub fn capture_region(&mut self, region: Region) -> Result<CaptureResult> {
         self.platform_capture.capture_region(region)
     }
 
@@ -461,7 +461,7 @@ impl Grim {
     ///
     /// # Arguments
     ///
-    /// * `region` - The region to capture, specified as a [`Box`]
+    /// * `region` - The region to capture, specified as a [`Region`]
     /// * `scale` - Scale factor for the output image
     ///
     /// # Errors
@@ -474,16 +474,20 @@ impl Grim {
     /// # Example
     ///
     /// ```rust,no_run
-    /// use grim_rs::{Grim, Box};
+    /// use grim_rs::{Grim, Region};
     ///
     /// let mut grim = Grim::new()?;
     /// // x=100, y=100, width=800, height=600
-    /// let region = Box::new(100, 100, 800, 600);
+    /// let region = Region::new(100, 100, 800, 600);
     /// let result = grim.capture_region_with_scale(region, 1.0)?;
     /// println!("Captured region: {}x{}", result.width(), result.height());
     /// # Ok::<(), grim_rs::Error>(())
     /// ```
-    pub fn capture_region_with_scale(&mut self, region: Box, scale: f64) -> Result<CaptureResult> {
+    pub fn capture_region_with_scale(
+        &mut self,
+        region: Region,
+        scale: f64,
+    ) -> Result<CaptureResult> {
         self.platform_capture
             .capture_region_with_scale(region, scale)
     }
@@ -509,7 +513,7 @@ impl Grim {
     /// # Example
     ///
     /// ```rust,no_run
-    /// use grim_rs::{Grim, CaptureParameters, Box};
+    /// use grim_rs::{Grim, CaptureParameters, Region};
     ///
     /// let mut grim = Grim::new()?;
     ///
@@ -524,7 +528,7 @@ impl Grim {
     ///
     /// // If we have a second output, capture a region of it
     /// if outputs.len() > 1 {
-    ///     let region = Box::new(0, 0, 400, 300);
+    ///     let region = Region::new(0, 0, 400, 300);
     ///     parameters.push(
     ///         CaptureParameters::new(outputs[1].name())
     ///             .region(region)
@@ -1211,7 +1215,7 @@ impl Grim {
     ///
     /// # Returns
     ///
-    /// Returns a `Box` representing the region read from stdin.
+    /// Returns a `Region` representing the region read from stdin.
     ///
     /// # Errors
     ///
@@ -1222,14 +1226,14 @@ impl Grim {
     /// # Example
     ///
     /// ```rust,no_run
-    /// use grim_rs::{Grim, Box};
+    /// use grim_rs::{Grim, Region};
     ///
     /// // Parse region from string (same format as stdin would provide)
-    /// let region = "100,100 800x600".parse::<Box>()?;
+    /// let region = "100,100 800x600".parse::<Region>()?;
     /// println!("Region: {}", region);
     /// # Ok::<(), grim_rs::Error>(())
     /// ```
-    pub fn read_region_from_stdin() -> Result<Box> {
+    pub fn read_region_from_stdin() -> Result<Region> {
         use std::io::{self, BufRead};
 
         let stdin = io::stdin();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@
 
 pub mod error;
 pub mod geometry;
+pub mod pixel_format;
 
 mod wayland_capture;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,6 +232,17 @@ impl MultiOutputCaptureResult {
     }
 }
 
+/// Backend protocol preference for capture initialization.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Backend {
+    /// Auto-detect: prefer `ext-image-copy-capture-v1`, fall back to `wlr-screencopy`.
+    Auto,
+    /// Force `ext-image-copy-capture-v1` (fails if not available).
+    ExtImageCopyCapture,
+    /// Force `wlr-screencopy` (fails if not available).
+    WlrScreencopy,
+}
+
 /// Main interface for taking screenshots.
 ///
 /// Provides methods for capturing screenshots of the entire screen,
@@ -241,16 +252,20 @@ pub struct Grim {
 }
 
 impl Grim {
-    /// Create a new Grim instance.
+    /// Create a new Grim instance with auto-detected backend.
     ///
     /// Establishes a connection to the Wayland compositor and initializes
-    /// the necessary protocols for screen capture.
+    /// the necessary protocols for screen capture. Prefers
+    /// `ext-image-copy-capture-v1` when available, falling back to
+    /// `wlr-screencopy`.
+    ///
+    /// Use [`Grim::new_ext`] or [`Grim::new_wlr`] to force a specific backend.
     ///
     /// # Errors
     ///
     /// Returns an error if:
     /// - Cannot connect to the Wayland compositor
-    /// - Required Wayland protocols are not available
+    /// - No capture protocol is available
     /// - Other initialization errors occur
     ///
     /// # Example
@@ -264,7 +279,63 @@ impl Grim {
     /// # }
     /// ```
     pub fn new() -> Result<Self> {
-        let platform_capture = PlatformCapture::new()?;
+        let platform_capture = PlatformCapture::new(Backend::Auto)?;
+        Ok(Self { platform_capture })
+    }
+
+    /// Create a new Grim instance forcing `ext-image-copy-capture-v1` backend.
+    ///
+    /// Fails if the compositor does not support this protocol (e.g. KDE, GNOME,
+    /// or older Sway releases). Use [`Grim::new`] for auto-detection if you need
+    /// to support multiple compositors.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::UnsupportedProtocol`] if `ext-image-copy-capture-v1`
+    /// is not available on the compositor.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use grim_rs::Grim;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// // Only works on compositors with ext-image-copy-capture-v1
+    /// // (Sway >= 2025, Hyprland, COSMIC)
+    /// let grim = Grim::new_ext()?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn new_ext() -> Result<Self> {
+        let platform_capture = PlatformCapture::new(Backend::ExtImageCopyCapture)?;
+        Ok(Self { platform_capture })
+    }
+
+    /// Create a new Grim instance forcing `wlr-screencopy` backend.
+    ///
+    /// Fails if the compositor does not support this protocol. Use
+    /// [`Grim::new`] for auto-detection if you need to support multiple
+    /// compositors.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::UnsupportedProtocol`] if `zwlr-screencopy-manager-v1`
+    /// is not available on the compositor.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use grim_rs::Grim;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// // Only works on compositors with wlr-screencopy
+    /// // (older Sway, River, Wayfire, Niri)
+    /// let grim = Grim::new_wlr()?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn new_wlr() -> Result<Self> {
+        let platform_capture = PlatformCapture::new(Backend::WlrScreencopy)?;
         Ok(Self { platform_capture })
     }
 

--- a/src/pixel_format.rs
+++ b/src/pixel_format.rs
@@ -1,0 +1,50 @@
+/// Pixel format variants for 32-bit RGBA-like layouts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum PixelFormat {
+    /// A, R, G, B — alpha in byte 0 (most significant).
+    Argb8888 = 0,
+    /// X, R, G, B — alpha unused, byte 0 ignored.
+    Xrgb8888 = 1,
+    /// A, B, G, R — alpha in byte 0.
+    Abgr8888 = 2,
+    /// X, B, G, R — alpha unused.
+    Xbgr8888 = 3,
+}
+
+/// Map a DRM fourcc code to a [`PixelFormat`].
+pub fn fourcc_to_format(fourcc: u32) -> Option<PixelFormat> {
+    match fourcc {
+        0x34325241 => Some(PixelFormat::Argb8888), // DRM_FORMAT_ARGB8888
+        0x34325258 => Some(PixelFormat::Xrgb8888), // DRM_FORMAT_XRGB8888
+        0x34324241 => Some(PixelFormat::Abgr8888), // DRM_FORMAT_ABGR8888
+        0x34324258 => Some(PixelFormat::Xbgr8888), // DRM_FORMAT_XBGR8888
+        _ => None,
+    }
+}
+
+/// Convert 32-bit pixel data from the given [`PixelFormat`] to RGBA byte order.
+///
+/// Conversion is done in-place on the slice. Unrecognized formats are left
+/// unchanged.
+pub fn convert_to_rgba(data: &mut [u8], format: PixelFormat) {
+    match format {
+        PixelFormat::Xrgb8888 => {
+            for chunk in data.chunks_exact_mut(4) {
+                chunk.swap(0, 2);
+                chunk[3] = 255;
+            }
+        }
+        PixelFormat::Argb8888 => {
+            for chunk in data.chunks_exact_mut(4) {
+                chunk.swap(0, 2);
+            }
+        }
+        PixelFormat::Xbgr8888 => {
+            for chunk in data.chunks_exact_mut(4) {
+                chunk[3] = 255;
+            }
+        }
+        PixelFormat::Abgr8888 => {}
+    }
+}

--- a/src/wayland_capture/capture.rs
+++ b/src/wayland_capture/capture.rs
@@ -102,10 +102,7 @@ impl WaylandCapture {
             {
                 let state = lock_frame_state(&frame_state)?;
                 if state.buffer.is_some() || state.ready || state.linux_dmabuf_received {
-                    if state.ready
-                        && state.buffer.is_none()
-                        && !state.linux_dmabuf_received
-                    {
+                    if state.ready && state.buffer.is_none() && !state.linux_dmabuf_received {
                         return Err(Error::FrameCapture(
                             "Frame is ready but buffer was not received".to_string(),
                         ));
@@ -520,8 +517,7 @@ impl WaylandCapture {
             if state.buffer.is_none() {
                 if state.linux_dmabuf_received {
                     let stride = state.width * 4;
-                    let size =
-                        checked_buffer_size(state.width, state.height, 4, Some(stride))?;
+                    let size = checked_buffer_size(state.width, state.height, 4, Some(stride))?;
                     state.buffer = Some(vec![0u8; size]);
                 } else {
                     return Err(Error::CaptureFailed);

--- a/src/wayland_capture/capture.rs
+++ b/src/wayland_capture/capture.rs
@@ -225,7 +225,9 @@ impl WaylandCapture {
         }
 
         let mut buffer_data = mmap.to_vec();
-        convert_shm_to_rgba(&mut buffer_data, format);
+        if let Some(pf) = shm_to_pixel(format) {
+            crate::pixel_format::convert_to_rgba(&mut buffer_data, pf);
+        }
         let output_id = output.id().protocol_id();
         let mut final_data = buffer_data;
         let mut final_width = width;
@@ -390,7 +392,9 @@ impl WaylandCapture {
             attempts += 1;
         }
         let mut buffer_data = mmap.to_vec();
-        convert_shm_to_rgba(&mut buffer_data, format);
+        if let Some(pf) = shm_to_pixel(format) {
+            crate::pixel_format::convert_to_rgba(&mut buffer_data, pf);
+        }
         let output_id = output.id().protocol_id();
         let (mut final_data, mut final_width, mut final_height) =
             self.apply_output_transform(buffer_data, full_width, full_height, output_id);
@@ -841,7 +845,9 @@ impl WaylandCapture {
                 state.format.unwrap_or(ShmFormat::Xrgb8888)
             };
             let mut buffer_data = mmap.to_vec();
-            convert_shm_to_rgba(&mut buffer_data, format);
+            if let Some(pf) = shm_to_pixel(format) {
+                crate::pixel_format::convert_to_rgba(&mut buffer_data, pf);
+            }
             let mut final_data = buffer_data;
             let mut final_width = width;
             let mut final_height = height;

--- a/src/wayland_capture/capture.rs
+++ b/src/wayland_capture/capture.rs
@@ -84,6 +84,7 @@ impl WaylandCapture {
             format: None,
             ready: false,
             flags: 0,
+            linux_dmabuf_received: false,
         }));
         let frame = screencopy_manager.capture_output_region(
             if overlay_cursor { 1 } else { 0 },
@@ -100,8 +101,11 @@ impl WaylandCapture {
         loop {
             {
                 let state = lock_frame_state(&frame_state)?;
-                if state.buffer.is_some() || state.ready {
-                    if state.ready && state.buffer.is_none() {
+                if state.buffer.is_some() || state.ready || state.linux_dmabuf_received {
+                    if state.ready
+                        && state.buffer.is_none()
+                        && !state.linux_dmabuf_received
+                    {
                         return Err(Error::FrameCapture(
                             "Frame is ready but buffer was not received".to_string(),
                         ));
@@ -118,6 +122,16 @@ impl WaylandCapture {
                 Error::FrameCapture(format!("Failed to dispatch frame events: {}", e))
             })?;
             attempts += 1;
+        }
+
+        // If we received linux_dmabuf but no Buffer event, populate buffer from dmabuf info.
+        {
+            let mut state = lock_frame_state(&frame_state)?;
+            if state.buffer.is_none() && state.linux_dmabuf_received {
+                let stride = state.width * 4;
+                let size = checked_buffer_size(state.width, state.height, 4, Some(stride))?;
+                state.buffer = Some(vec![0u8; size]);
+            }
         }
 
         let shm = self
@@ -460,6 +474,7 @@ impl WaylandCapture {
                 format: None,
                 ready: false,
                 flags: 0,
+                linux_dmabuf_received: false,
             }));
             let frame = screencopy_manager.capture_output_region(
                 if param.overlay_cursor_enabled() { 1 } else { 0 },
@@ -484,7 +499,7 @@ impl WaylandCapture {
                     state
                         .lock()
                         .ok()
-                        .is_some_and(|s| s.buffer.is_some() || s.ready)
+                        .is_some_and(|s| s.buffer.is_some() || s.ready || s.linux_dmabuf_received)
                 })
                 .count();
             if completed_frames >= total_frames {
@@ -501,9 +516,16 @@ impl WaylandCapture {
             ));
         }
         for frame_state in frame_states.values() {
-            let state = lock_frame_state(frame_state)?;
+            let mut state = lock_frame_state(frame_state)?;
             if state.buffer.is_none() {
-                return Err(Error::CaptureFailed);
+                if state.linux_dmabuf_received {
+                    let stride = state.width * 4;
+                    let size =
+                        checked_buffer_size(state.width, state.height, 4, Some(stride))?;
+                    state.buffer = Some(vec![0u8; size]);
+                } else {
+                    return Err(Error::CaptureFailed);
+                }
             }
         }
         let mut buffers: HashMap<String, (tempfile::NamedTempFile, memmap2::MmapMut)> =

--- a/src/wayland_capture/capture.rs
+++ b/src/wayland_capture/capture.rs
@@ -54,7 +54,7 @@ impl WaylandCapture {
     fn capture_region_for_output(
         &mut self,
         output: &WlOutput,
-        region: Box,
+        region: Region,
         overlay_cursor: bool,
     ) -> Result<CaptureResult> {
         if region.width() <= 0 || region.height() <= 0 {
@@ -244,7 +244,7 @@ impl WaylandCapture {
 
     fn composite_region(
         &mut self,
-        region: Box,
+        region: Region,
         outputs: &[(WlOutput, OutputInfo)],
         overlay_cursor: bool,
     ) -> Result<CaptureResult> {
@@ -267,7 +267,7 @@ impl WaylandCapture {
         let mut any_capture = false;
 
         for (output, info) in outputs {
-            let output_box = Box::new(
+            let output_box = Region::new(
                 info.logical_x,
                 info.logical_y,
                 info.logical_width,
@@ -283,7 +283,7 @@ impl WaylandCapture {
                 } else {
                     info.scale as f64
                 };
-                let local_region = Box::new(
+                let local_region = Region::new(
                     intersection.x() - info.logical_x,
                     intersection.y() - info.logical_y,
                     intersection.width(),
@@ -343,7 +343,7 @@ impl WaylandCapture {
 
                 Output {
                     name: info.name.clone(),
-                    geometry: Box::new(x, y, width, height),
+                    geometry: Region::new(x, y, width, height),
                     scale: info.scale,
                     description: info.description.clone(),
                 }
@@ -375,7 +375,7 @@ impl WaylandCapture {
             max_y = max_y.max(info.logical_y + info.logical_height);
         }
 
-        let region = Box::new(min_x, min_y, max_x - min_x, max_y - min_y);
+        let region = Region::new(min_x, min_y, max_x - min_x, max_y - min_y);
         self.composite_region(region, &snapshot, false)
     }
 
@@ -392,7 +392,7 @@ impl WaylandCapture {
             .find(|(_, info)| info.name == output_name)
             .ok_or_else(|| Error::OutputNotFound(output_name.to_string()))?;
 
-        let local_region = Box::new(0, 0, info.logical_width, info.logical_height);
+        let local_region = Region::new(0, 0, info.logical_width, info.logical_height);
         self.capture_region_for_output(&output_handle, local_region, false)
     }
 
@@ -405,13 +405,17 @@ impl WaylandCapture {
         self.scale_image_data(result, scale)
     }
 
-    pub fn capture_region(&mut self, region: Box) -> Result<CaptureResult> {
+    pub fn capture_region(&mut self, region: Region) -> Result<CaptureResult> {
         self.refresh_outputs()?;
         let snapshot = self.collect_outputs_snapshot();
         self.composite_region(region, &snapshot, false)
     }
 
-    pub fn capture_region_with_scale(&mut self, region: Box, scale: f64) -> Result<CaptureResult> {
+    pub fn capture_region_with_scale(
+        &mut self,
+        region: Region,
+        scale: f64,
+    ) -> Result<CaptureResult> {
         let result = self.capture_region(region)?;
         self.scale_image_data(result, scale)
     }
@@ -462,7 +466,7 @@ impl WaylandCapture {
                 }
                 *region
             } else {
-                Box::new(0, 0, output_info.logical_width, output_info.logical_height)
+                Region::new(0, 0, output_info.logical_width, output_info.logical_height)
             };
             let frame_state = Arc::new(Mutex::new(FrameState {
                 buffer: None,

--- a/src/wayland_capture/capture.rs
+++ b/src/wayland_capture/capture.rs
@@ -1,5 +1,6 @@
 use super::transform::{apply_image_transform, flip_vertical};
 use super::*;
+use wayland_protocols::ext::image_copy_capture::v1::client::ext_image_copy_capture_manager_v1::Options as ExtCopyOptions;
 
 impl WaylandCapture {
     fn refresh_outputs(&mut self) -> Result<()> {
@@ -57,6 +58,7 @@ impl WaylandCapture {
         region: Region,
         overlay_cursor: bool,
     ) -> Result<CaptureResult> {
+        // Validation is shared
         if region.width() <= 0 || region.height() <= 0 {
             return Err(Error::InvalidRegion(
                 "Capture region must have positive width and height".to_string(),
@@ -68,13 +70,32 @@ impl WaylandCapture {
             ));
         }
 
-        let screencopy_manager =
-            self.globals
-                .screencopy_manager
-                .as_ref()
-                .ok_or(Error::UnsupportedProtocol(
-                    "zwlr_screencopy_manager_v1 not available".to_string(),
-                ))?;
+        let backend = self.backend_cloned()?;
+        match backend {
+            CaptureBackend::WlrScreencopy { manager } => {
+                self.capture_region_wlr(&manager, output, region, overlay_cursor)
+            }
+            CaptureBackend::ExtImageCopyCapture {
+                source_manager,
+                copy_manager,
+            } => self.capture_region_ext(
+                &source_manager,
+                &copy_manager,
+                output,
+                region,
+                overlay_cursor,
+            ),
+        }
+    }
+
+    fn capture_region_wlr(
+        &mut self,
+        manager: &ZwlrScreencopyManagerV1,
+        output: &WlOutput,
+        region: Region,
+        overlay_cursor: bool,
+    ) -> Result<CaptureResult> {
+        let screencopy_manager = manager;
         let mut event_queue = self._connection.new_event_queue();
         let qh = event_queue.handle();
         let frame_state = Arc::new(Mutex::new(FrameState {
@@ -85,6 +106,7 @@ impl WaylandCapture {
             ready: false,
             flags: 0,
             linux_dmabuf_received: false,
+            constraints_done: false,
         }));
         let frame = screencopy_manager.capture_output_region(
             if overlay_cursor { 1 } else { 0 },
@@ -233,6 +255,185 @@ impl WaylandCapture {
             final_data = inverted_data;
             final_width = inv_width;
             final_height = inv_height;
+        }
+
+        Ok(CaptureResult {
+            data: final_data,
+            width: final_width,
+            height: final_height,
+        })
+    }
+
+    fn capture_region_ext(
+        &mut self,
+        source_manager: &ExtOutputImageCaptureSourceManagerV1,
+        copy_manager: &ExtImageCopyCaptureManagerV1,
+        output: &WlOutput,
+        region: Region,
+        overlay_cursor: bool,
+    ) -> Result<CaptureResult> {
+        let mut event_queue = self._connection.new_event_queue();
+        let qh = event_queue.handle();
+        let frame_state = Arc::new(Mutex::new(FrameState {
+            buffer: None,
+            width: 0,
+            height: 0,
+            format: None,
+            ready: false,
+            flags: 0,
+            linux_dmabuf_received: false,
+            constraints_done: false,
+        }));
+        let source = source_manager.create_source(output, &qh, ());
+        let mut options = ExtCopyOptions::empty();
+        if overlay_cursor {
+            options |= ExtCopyOptions::PaintCursors;
+        }
+        let _session = copy_manager.create_session(&source, options, &qh, frame_state.clone());
+
+        let mut attempts = 0;
+        loop {
+            {
+                let state = lock_frame_state(&frame_state)?;
+                if state.constraints_done {
+                    break;
+                }
+            }
+            if attempts >= MAX_ATTEMPTS {
+                return Err(Error::FrameCapture(
+                    "Timeout waiting for session constraints".to_string(),
+                ));
+            }
+            event_queue.blocking_dispatch(self).map_err(|e| {
+                Error::FrameCapture(format!("Failed to dispatch session events: {}", e))
+            })?;
+            attempts += 1;
+        }
+
+        let (full_width, full_height, format) = {
+            let state = lock_frame_state(&frame_state)?;
+            if state.width == 0 || state.height == 0 {
+                return Err(Error::CaptureFailed);
+            }
+            (
+                state.width,
+                state.height,
+                state.format.unwrap_or(ShmFormat::Xrgb8888),
+            )
+        };
+
+        let stride = full_width * 4;
+        let size = checked_buffer_size(full_width, full_height, 4, Some(stride))?;
+        let shm = self
+            .globals
+            .shm
+            .as_ref()
+            .ok_or_else(|| Error::UnsupportedProtocol("wl_shm not available".to_string()))?;
+        let mut tmp_file = tempfile::NamedTempFile::new().map_err(|e| {
+            Error::BufferCreation(format!("failed to create temporary file: {}", e))
+        })?;
+        tmp_file.as_file_mut().set_len(size as u64).map_err(|e| {
+            Error::BufferCreation(format!("failed to resize buffer to {} bytes: {}", size, e))
+        })?;
+        let mmap = unsafe {
+            memmap2::MmapMut::map_mut(&tmp_file)
+                .map_err(|e| Error::BufferCreation(format!("failed to memory-map buffer: {}", e)))?
+        };
+        let pool = shm.create_pool(
+            unsafe { BorrowedFd::borrow_raw(tmp_file.as_file().as_raw_fd()) },
+            size as i32,
+            &qh,
+            (),
+        );
+        let buffer = pool.create_buffer(
+            0,
+            full_width as i32,
+            full_height as i32,
+            stride as i32,
+            format,
+            &qh,
+            (),
+        );
+
+        // Set buffer placeholder — ext doesn't have a Buffer event like wlr
+        {
+            let mut state = lock_frame_state(&frame_state)?;
+            state.buffer = Some(vec![0u8; size]);
+        }
+
+        // create frame, attach buffer, capture
+        let frame = _session.create_frame(&qh, frame_state.clone());
+        frame.attach_buffer(&buffer);
+        frame.damage_buffer(0, 0, full_width as i32, full_height as i32);
+        frame.capture();
+        let mut attempts = 0;
+        loop {
+            {
+                let state = lock_frame_state(&frame_state)?;
+                if state.ready {
+                    if state.buffer.is_none() {
+                        return Err(Error::FrameCapture(
+                            "Frame is ready but buffer was not received".to_string(),
+                        ));
+                    }
+                    break;
+                }
+            }
+            if attempts >= MAX_ATTEMPTS {
+                return Err(Error::FrameCapture(
+                    "Timeout waiting for frame capture completion".to_string(),
+                ));
+            }
+            event_queue.blocking_dispatch(self).map_err(|e| {
+                Error::FrameCapture(format!("Failed to dispatch frame events: {}", e))
+            })?;
+            attempts += 1;
+        }
+        let mut buffer_data = mmap.to_vec();
+        convert_shm_to_rgba(&mut buffer_data, format);
+        let output_id = output.id().protocol_id();
+        let (mut final_data, mut final_width, mut final_height) =
+            self.apply_output_transform(buffer_data, full_width, full_height, output_id);
+        let region_w = region.width() as u32;
+        let region_h = region.height() as u32;
+        let need_crop = {
+            let info = self.globals.output_info.get(&output_id);
+            info.is_none_or(|info| {
+                region.x() != 0
+                    || region.y() != 0
+                    || region_w as i32 != info.logical_width
+                    || region_h as i32 != info.logical_height
+            })
+        };
+
+        if need_crop && region_w > 0 && region_h > 0 {
+            let scale = self
+                .globals
+                .output_info
+                .get(&output_id)
+                .map_or(1.0, |info| {
+                    if info.logical_scale_known && info.logical_scale.is_finite() {
+                        info.logical_scale
+                    } else {
+                        info.scale as f64
+                    }
+                });
+            let crop_x = ((region.x() as f64) * scale) as usize;
+            let crop_y = ((region.y() as f64) * scale) as usize;
+            let crop_w = ((region_w as f64) * scale) as u32;
+            let crop_h = ((region_h as f64) * scale) as u32;
+            let (cropped, cw, ch) = crop_rgba(
+                &final_data,
+                final_width,
+                final_height,
+                crop_x,
+                crop_y,
+                crop_w,
+                crop_h,
+            );
+            final_data = cropped;
+            final_width = cw;
+            final_height = ch;
         }
 
         Ok(CaptureResult {
@@ -426,13 +627,24 @@ impl WaylandCapture {
     ) -> Result<MultiOutputCaptureResult> {
         self.refresh_outputs()?;
 
-        let screencopy_manager =
-            self.globals
-                .screencopy_manager
-                .as_ref()
-                .ok_or(Error::UnsupportedProtocol(
-                    "zwlr_screencopy_manager_v1 not available".to_string(),
-                ))?;
+        let backend = self.backend_cloned()?;
+        match backend {
+            CaptureBackend::WlrScreencopy { manager } => {
+                self.capture_outputs_wlr(manager, parameters)
+            }
+            CaptureBackend::ExtImageCopyCapture {
+                source_manager,
+                copy_manager,
+            } => self.capture_outputs_ext(source_manager, copy_manager, parameters),
+        }
+    }
+
+    fn capture_outputs_wlr(
+        &mut self,
+        manager: ZwlrScreencopyManagerV1,
+        parameters: Vec<CaptureParameters>,
+    ) -> Result<MultiOutputCaptureResult> {
+        let screencopy_manager = &manager;
         let mut event_queue = self._connection.new_event_queue();
         let qh = event_queue.handle();
         let mut frame_states: HashMap<String, Arc<Mutex<FrameState>>> = HashMap::new();
@@ -476,6 +688,7 @@ impl WaylandCapture {
                 ready: false,
                 flags: 0,
                 linux_dmabuf_received: false,
+                constraints_done: false,
             }));
             let frame = screencopy_manager.capture_output_region(
                 if param.overlay_cursor_enabled() { 1 } else { 0 },
@@ -679,6 +892,58 @@ impl WaylandCapture {
         Ok(MultiOutputCaptureResult::new(results))
     }
 
+    fn capture_outputs_ext(
+        &mut self,
+        source_manager: ExtOutputImageCaptureSourceManagerV1,
+        copy_manager: ExtImageCopyCaptureManagerV1,
+        parameters: Vec<CaptureParameters>,
+    ) -> Result<MultiOutputCaptureResult> {
+        let mut results = HashMap::new();
+        for param in &parameters {
+            let (output_id, output_info) = self
+                .globals
+                .output_info
+                .iter()
+                .find(|(_, info)| info.name == param.output_name())
+                .ok_or_else(|| Error::OutputNotFound(param.output_name().to_string()))?;
+
+            let region = if let Some(region) = param.region_ref() {
+                let output_right = output_info.logical_width;
+                let output_bottom = output_info.logical_height;
+                if region.x() < 0
+                    || region.y() < 0
+                    || region.x() + region.width() > output_right
+                    || region.y() + region.height() > output_bottom
+                {
+                    return Err(Error::InvalidRegion(
+                        "Capture region extends outside output boundaries".to_string(),
+                    ));
+                }
+                *region
+            } else {
+                Region::new(0, 0, output_info.logical_width, output_info.logical_height)
+            };
+            let output_clone = {
+                let output = self
+                    .globals
+                    .outputs
+                    .iter()
+                    .find(|o| o.id().protocol_id() == *output_id)
+                    .ok_or_else(|| Error::OutputNotFound(param.output_name().to_string()))?;
+                output.clone()
+            };
+            let capture = self.capture_region_ext(
+                &source_manager,
+                &copy_manager,
+                &output_clone,
+                region,
+                param.overlay_cursor_enabled(),
+            )?;
+            results.insert(param.output_name().to_string(), capture);
+        }
+        Ok(MultiOutputCaptureResult::new(results))
+    }
+
     pub fn capture_outputs_with_scale(
         &mut self,
         parameters: Vec<CaptureParameters>,
@@ -695,4 +960,45 @@ impl WaylandCapture {
 
         Ok(MultiOutputCaptureResult::new(scaled_results))
     }
+
+    fn apply_output_transform(
+        &self,
+        data: Vec<u8>,
+        width: u32,
+        height: u32,
+        output_id: u32,
+    ) -> (Vec<u8>, u32, u32) {
+        if let Some(info) = self.globals.output_info.get(&output_id) {
+            if !matches!(
+                info.transform,
+                wayland_client::protocol::wl_output::Transform::Normal
+            ) {
+                return transform::apply_image_transform(&data, width, height, info.transform);
+            }
+        }
+        (data, width, height)
+    }
+}
+
+fn crop_rgba(
+    data: &[u8],
+    full_width: u32,
+    full_height: u32,
+    x: usize,
+    y: usize,
+    width: u32,
+    height: u32,
+) -> (Vec<u8>, u32, u32) {
+    let w = (width as usize).min(full_width as usize - x.min(full_width as usize));
+    let h = (height as usize).min(full_height as usize - y.min(full_height as usize));
+    if w == 0 || h == 0 {
+        return (Vec::new(), 0, 0);
+    }
+    let mut out = vec![0u8; w * h * 4];
+    for row in 0..h {
+        let src_start = ((y + row) * full_width as usize + x) * 4;
+        let dst_start = row * w * 4;
+        out[dst_start..dst_start + w * 4].copy_from_slice(&data[src_start..src_start + w * 4]);
+    }
+    (out, w as u32, h as u32)
 }

--- a/src/wayland_capture/mod.rs
+++ b/src/wayland_capture/mod.rs
@@ -23,6 +23,16 @@ pub(super) use wayland_protocols_wlr::screencopy::v1::client::{
     zwlr_screencopy_manager_v1::ZwlrScreencopyManagerV1,
 };
 
+pub(super) use wayland_protocols::ext::image_capture_source::v1::client::{
+    ext_image_capture_source_v1::ExtImageCaptureSourceV1,
+    ext_output_image_capture_source_manager_v1::ExtOutputImageCaptureSourceManagerV1,
+};
+pub(super) use wayland_protocols::ext::image_copy_capture::v1::client::{
+    ext_image_copy_capture_frame_v1::ExtImageCopyCaptureFrameV1,
+    ext_image_copy_capture_manager_v1::ExtImageCopyCaptureManagerV1,
+    ext_image_copy_capture_session_v1::ExtImageCopyCaptureSessionV1,
+};
+
 mod capture;
 mod scaling;
 mod transform;
@@ -31,18 +41,19 @@ mod wayland_events;
 pub(super) const ZWLR_SCREENCOPY_FRAME_V1_FLAGS_Y_INVERT: u32 = 1;
 pub(super) const MAX_ATTEMPTS: usize = 100;
 
-/// Global upper bound for pixel count used by `checked_buffer_size()`.
-///
-/// This limit is enforced for all image/buffer allocations that are derived
-/// from width/height in this module, including:
-/// - `capture_region_for_output()` (Wayland buffer allocation via stride×height)
-/// - `capture_outputs()` (per-output buffer allocation)
-/// - `composite_region()` (final composited image buffer)
-/// - `scale_image_data()` and `scale_image_integer_fast()` (scaled image buffers)
-/// - `ZwlrScreencopyFrameV1::Buffer` event handling (frame buffer placeholder)
-///
-/// The goal is to prevent integer overflows and avoid OOM from extreme sizes.
 pub(super) const MAX_PIXELS: u64 = 134_217_728;
+
+/// Captures which capture protocol is in use and holds its specific manager objects.
+#[derive(Clone)]
+pub(super) enum CaptureBackend {
+    WlrScreencopy {
+        manager: ZwlrScreencopyManagerV1,
+    },
+    ExtImageCopyCapture {
+        source_manager: ExtOutputImageCaptureSourceManagerV1,
+        copy_manager: ExtImageCopyCaptureManagerV1,
+    },
+}
 
 #[derive(Debug, Clone)]
 pub(super) struct FrameState {
@@ -53,6 +64,7 @@ pub(super) struct FrameState {
     ready: bool,
     flags: u32,
     linux_dmabuf_received: bool,
+    constraints_done: bool,
 }
 
 /// Compute a safe buffer size in bytes for image-like data.
@@ -106,8 +118,6 @@ pub(super) fn checked_buffer_size(
 }
 
 /// Safely lock a FrameState mutex, converting poisoned mutex errors to Result.
-///
-/// This helper function provides proper error handling for mutex locks instead of panicking.
 pub(super) fn lock_frame_state(
     frame_state: &Arc<Mutex<FrameState>>,
 ) -> Result<std::sync::MutexGuard<'_, FrameState>> {
@@ -117,60 +127,35 @@ pub(super) fn lock_frame_state(
 }
 
 /// Map a DRM fourcc format code to the equivalent `wl_shm` Format.
-///
-/// The `zwlr_screencopy` protocol delivers dmabuf frames with DRM fourcc
-/// codes.  For the 32-bit RGB layouts the fourcc values are identical to
-/// the `wl_shm` format enum values, so the rest of the pipeline
-/// (`convert_shm_to_rgba`) can process them unchanged.
-///
-/// Unknown fourcc codes return `None` — callers should fall back to a
-/// reasonable default.
 pub(super) fn drm_fourcc_to_shm_format(fourcc: u32) -> Option<ShmFormat> {
     match fourcc {
-        0x34325241 => Some(ShmFormat::Argb8888), // DRM_FORMAT_ARGB8888
-        0x34325258 => Some(ShmFormat::Xrgb8888), // DRM_FORMAT_XRGB8888
-        0x34324241 => Some(ShmFormat::Abgr8888), // DRM_FORMAT_ABGR8888
-        0x34324258 => Some(ShmFormat::Xbgr8888), // DRM_FORMAT_XBGR8888
+        0x34325241 => Some(ShmFormat::Argb8888),
+        0x34325258 => Some(ShmFormat::Xrgb8888),
+        0x34324241 => Some(ShmFormat::Abgr8888),
+        0x34324258 => Some(ShmFormat::Xbgr8888),
         _ => None,
     }
 }
 
 /// `wl_shm` 32-bit frame bytes to the crate's internal RGBA layout.
-///
-/// Why this exists:
-/// - `CaptureResult` data is exposed as RGBA.
-/// - `wl_shm` formats (`Xrgb8888`, `Argb8888`, etc.) are word-defined and on
-///   little-endian systems their byte order in memory is not always RGBA.
-///
-/// Where this is used:
-/// - `capture_region_for_output()` after reading the mmap buffer.
-/// - `capture_outputs()` for each captured output buffer.
-///
-/// Notes:
-/// - Conversion is done in-place (no extra allocation).
-/// - Unsupported formats are left unchanged.
 pub(super) fn convert_shm_to_rgba(buffer_data: &mut [u8], format: ShmFormat) {
     match format {
-        // x:R:G:B -> bytes in memory are B,G,R,x on little-endian.
         ShmFormat::Xrgb8888 => {
             for chunk in buffer_data.chunks_exact_mut(4) {
                 chunk.swap(0, 2);
                 chunk[3] = 255;
             }
         }
-        // A:R:G:B -> bytes in memory are B,G,R,A on little-endian.
         ShmFormat::Argb8888 => {
             for chunk in buffer_data.chunks_exact_mut(4) {
                 chunk.swap(0, 2);
             }
         }
-        // x:B:G:R -> bytes in memory are R,G,B,x on little-endian.
         ShmFormat::Xbgr8888 => {
             for chunk in buffer_data.chunks_exact_mut(4) {
                 chunk[3] = 255;
             }
         }
-        // A:B:G:R -> bytes in memory are R,G,B,A on little-endian.
         ShmFormat::Abgr8888 => {}
         _ => {}
     }
@@ -193,17 +178,11 @@ pub(super) fn guess_output_logical_geometry(info: &mut OutputInfo) {
 }
 
 /// Infer a (possibly fractional) logical scale.
-///
-/// Some compositors report a logical size that does not match the integer `wl_output.scale`.
-/// To match grim's behavior, we derive the effective scale from the physical mode size and the
-/// logical size (taking output transform into account).
 pub(super) fn update_logical_scale(info: &mut OutputInfo) {
     if info.width <= 0 || info.height <= 0 || info.logical_width <= 0 || info.logical_height <= 0 {
         return;
     }
 
-    // Match grim's behavior: infer a (possibly fractional) logical scale from the output's
-    // physical mode size and the xdg-output logical size.
     let mut physical_width = info.width;
     let mut physical_height = info.height;
     transform::apply_output_transform(info.transform, &mut physical_width, &mut physical_height);
@@ -248,26 +227,28 @@ pub(super) fn blit_capture(
 
 #[derive(Clone)]
 pub(super) struct OutputInfo {
-    name: String,
-    width: i32,
-    height: i32,
-    x: i32,
-    y: i32,
-    scale: i32,
-    transform: wayland_client::protocol::wl_output::Transform,
-    logical_x: i32,
-    logical_y: i32,
-    logical_width: i32,
-    logical_height: i32,
-    logical_scale_known: bool,
-    logical_scale: f64,
-    description: Option<String>,
+    pub(super) name: String,
+    pub(super) width: i32,
+    pub(super) height: i32,
+    pub(super) x: i32,
+    pub(super) y: i32,
+    pub(super) scale: i32,
+    pub(super) transform: wayland_client::protocol::wl_output::Transform,
+    pub(super) logical_x: i32,
+    pub(super) logical_y: i32,
+    pub(super) logical_width: i32,
+    pub(super) logical_height: i32,
+    pub(super) logical_scale_known: bool,
+    pub(super) logical_scale: f64,
+    pub(super) description: Option<String>,
 }
 
 pub(super) struct WaylandGlobals {
     compositor: Option<WlCompositor>,
     shm: Option<WlShm>,
     screencopy_manager: Option<ZwlrScreencopyManagerV1>,
+    ext_source_manager: Option<ExtOutputImageCaptureSourceManagerV1>,
+    ext_copy_manager: Option<ExtImageCopyCaptureManagerV1>,
     xdg_output_manager: Option<ZxdgOutputManagerV1>,
     outputs: Vec<WlOutput>,
     output_info: HashMap<u32, OutputInfo>,
@@ -277,10 +258,21 @@ pub(super) struct WaylandGlobals {
 pub struct WaylandCapture {
     _connection: Connection,
     globals: WaylandGlobals,
+    backend: Option<CaptureBackend>,
 }
 
 impl WaylandCapture {
-    pub fn new() -> Result<Self> {
+    fn try_backend(&self) -> Result<&CaptureBackend> {
+        self.backend.as_ref().ok_or_else(|| {
+            Error::WaylandConnection("WaylandCapture backend not initialized".to_string())
+        })
+    }
+
+    fn backend_cloned(&self) -> Result<CaptureBackend> {
+        Ok(self.try_backend()?.clone())
+    }
+
+    pub fn new(preference: crate::Backend) -> Result<Self> {
         let connection = Connection::connect_to_env().map_err(|e| {
             Error::WaylandConnection(format!("Failed to connect to Wayland: {}", e))
         })?;
@@ -288,31 +280,92 @@ impl WaylandCapture {
             compositor: None,
             shm: None,
             screencopy_manager: None,
+            ext_source_manager: None,
+            ext_copy_manager: None,
             xdg_output_manager: None,
             outputs: Vec::new(),
             output_info: HashMap::new(),
             output_xdg_map: HashMap::new(),
         };
+
         let mut event_queue = connection.new_event_queue();
         let qh = event_queue.handle();
         let _registry = connection.display().get_registry(&qh, ());
         let mut instance = Self {
             _connection: connection,
             globals,
+            backend: None,
         };
         event_queue.roundtrip(&mut instance).map_err(|e| {
             Error::WaylandConnection(format!("Failed to initialize Wayland globals: {}", e))
         })?;
-        if instance.globals.screencopy_manager.is_none() {
-            return Err(Error::UnsupportedProtocol(
-                "zwlr_screencopy_manager_v1 not available".to_string(),
-            ));
-        }
+
+        let backend = match preference {
+            crate::Backend::ExtImageCopyCapture => {
+                let source_manager =
+                    instance.globals.ext_source_manager.take().ok_or_else(|| {
+                        Error::UnsupportedProtocol(
+                            "ext-image-copy-capture-v1 not available".to_string(),
+                        )
+                    })?;
+                let copy_manager = instance.globals.ext_copy_manager.take().ok_or_else(|| {
+                    Error::UnsupportedProtocol(
+                        "ext-image-copy-capture-v1 not available".to_string(),
+                    )
+                })?;
+                CaptureBackend::ExtImageCopyCapture {
+                    source_manager,
+                    copy_manager,
+                }
+            }
+            crate::Backend::WlrScreencopy => {
+                let mgr = instance.globals.screencopy_manager.take().ok_or_else(|| {
+                    Error::UnsupportedProtocol(
+                        "zwlr-screencopy-manager-v1 not available".to_string(),
+                    )
+                })?;
+                CaptureBackend::WlrScreencopy { manager: mgr }
+            }
+            crate::Backend::Auto => {
+                // Prefer ext-image-copy-capture, fall back to wlr-screencopy
+                match (
+                    instance.globals.ext_source_manager.take(),
+                    instance.globals.ext_copy_manager.take(),
+                ) {
+                    (Some(source_manager), Some(copy_manager)) => {
+                        CaptureBackend::ExtImageCopyCapture {
+                            source_manager,
+                            copy_manager,
+                        }
+                    }
+                    _ => {
+                        let manager =
+                            instance.globals.screencopy_manager.take().ok_or_else(|| {
+                                Error::UnsupportedProtocol(
+                                    "No capture protocol available (tried \
+                                     ext-image-copy-capture-v1 and \
+                                     zwlr-screencopy-manager-v1)"
+                                        .to_string(),
+                                )
+                            })?;
+                        CaptureBackend::WlrScreencopy { manager }
+                    }
+                }
+            }
+        };
+
         if instance.globals.shm.is_none() {
             return Err(Error::UnsupportedProtocol(
                 "wl_shm not available".to_string(),
             ));
         }
+
+        let backend_label = match &backend {
+            CaptureBackend::WlrScreencopy { .. } => "wlr-screencopy",
+            CaptureBackend::ExtImageCopyCapture { .. } => "ext-image-copy-capture-v1",
+        };
+        log::info!("grim-rs: using {} backend", backend_label);
+        instance.backend = Some(backend);
         Ok(instance)
     }
 }

--- a/src/wayland_capture/mod.rs
+++ b/src/wayland_capture/mod.rs
@@ -52,6 +52,7 @@ pub(super) struct FrameState {
     format: Option<ShmFormat>,
     ready: bool,
     flags: u32,
+    linux_dmabuf_received: bool,
 }
 
 /// Compute a safe buffer size in bytes for image-like data.
@@ -113,6 +114,25 @@ pub(super) fn lock_frame_state(
     frame_state
         .lock()
         .map_err(|e| Error::FrameCapture(format!("Frame state mutex poisoned: {}", e)))
+}
+
+/// Map a DRM fourcc format code to the equivalent `wl_shm` Format.
+///
+/// The `zwlr_screencopy` protocol delivers dmabuf frames with DRM fourcc
+/// codes.  For the 32-bit RGB layouts the fourcc values are identical to
+/// the `wl_shm` format enum values, so the rest of the pipeline
+/// (`convert_shm_to_rgba`) can process them unchanged.
+///
+/// Unknown fourcc codes return `None` — callers should fall back to a
+/// reasonable default.
+pub(super) fn drm_fourcc_to_shm_format(fourcc: u32) -> Option<ShmFormat> {
+    match fourcc {
+        0x34325241 => Some(ShmFormat::Argb8888), // DRM_FORMAT_ARGB8888
+        0x34325258 => Some(ShmFormat::Xrgb8888), // DRM_FORMAT_XRGB8888
+        0x34324241 => Some(ShmFormat::Abgr8888), // DRM_FORMAT_ABGR8888
+        0x34324258 => Some(ShmFormat::Xbgr8888), // DRM_FORMAT_XBGR8888
+        _ => None,
+    }
 }
 
 /// `wl_shm` 32-bit frame bytes to the crate's internal RGBA layout.

--- a/src/wayland_capture/mod.rs
+++ b/src/wayland_capture/mod.rs
@@ -1,5 +1,5 @@
 pub(super) use crate::{
-    Box, CaptureParameters, CaptureResult, Error, MultiOutputCaptureResult, Output, Result,
+    CaptureParameters, CaptureResult, Error, MultiOutputCaptureResult, Output, Region, Result,
 };
 pub(super) use std::collections::HashMap;
 pub(super) use std::os::fd::{AsRawFd, BorrowedFd};

--- a/src/wayland_capture/mod.rs
+++ b/src/wayland_capture/mod.rs
@@ -126,38 +126,28 @@ pub(super) fn lock_frame_state(
         .map_err(|e| Error::FrameCapture(format!("Frame state mutex poisoned: {}", e)))
 }
 
-/// Map a DRM fourcc format code to the equivalent `wl_shm` Format.
-pub(super) fn drm_fourcc_to_shm_format(fourcc: u32) -> Option<ShmFormat> {
-    match fourcc {
-        0x34325241 => Some(ShmFormat::Argb8888),
-        0x34325258 => Some(ShmFormat::Xrgb8888),
-        0x34324241 => Some(ShmFormat::Abgr8888),
-        0x34324258 => Some(ShmFormat::Xbgr8888),
+/// Convert a `wl_shm::Format` to our internal [`PixelFormat`].
+fn shm_to_pixel(format: ShmFormat) -> Option<crate::pixel_format::PixelFormat> {
+    match format {
+        ShmFormat::Argb8888 => Some(crate::pixel_format::PixelFormat::Argb8888),
+        ShmFormat::Xrgb8888 => Some(crate::pixel_format::PixelFormat::Xrgb8888),
+        ShmFormat::Abgr8888 => Some(crate::pixel_format::PixelFormat::Abgr8888),
+        ShmFormat::Xbgr8888 => Some(crate::pixel_format::PixelFormat::Xbgr8888),
         _ => None,
     }
 }
 
-/// `wl_shm` 32-bit frame bytes to the crate's internal RGBA layout.
-pub(super) fn convert_shm_to_rgba(buffer_data: &mut [u8], format: ShmFormat) {
+/// Map a DRM fourcc code through to [`PixelFormat`], used internally for dmabuf events.
+fn drm_fourcc_to_pixel(fourcc: u32) -> Option<crate::pixel_format::PixelFormat> {
+    crate::pixel_format::fourcc_to_format(fourcc)
+}
+
+fn pixel_to_shm(format: crate::pixel_format::PixelFormat) -> ShmFormat {
     match format {
-        ShmFormat::Xrgb8888 => {
-            for chunk in buffer_data.chunks_exact_mut(4) {
-                chunk.swap(0, 2);
-                chunk[3] = 255;
-            }
-        }
-        ShmFormat::Argb8888 => {
-            for chunk in buffer_data.chunks_exact_mut(4) {
-                chunk.swap(0, 2);
-            }
-        }
-        ShmFormat::Xbgr8888 => {
-            for chunk in buffer_data.chunks_exact_mut(4) {
-                chunk[3] = 255;
-            }
-        }
-        ShmFormat::Abgr8888 => {}
-        _ => {}
+        crate::pixel_format::PixelFormat::Argb8888 => ShmFormat::Argb8888,
+        crate::pixel_format::PixelFormat::Xrgb8888 => ShmFormat::Xrgb8888,
+        crate::pixel_format::PixelFormat::Abgr8888 => ShmFormat::Abgr8888,
+        crate::pixel_format::PixelFormat::Xbgr8888 => ShmFormat::Xbgr8888,
     }
 }
 

--- a/src/wayland_capture/wayland_events.rs
+++ b/src/wayland_capture/wayland_events.rs
@@ -327,7 +327,7 @@ impl Dispatch<ZwlrScreencopyFrameV1, Arc<Mutex<FrameState>>> for WaylandCapture 
                     state.height = height;
                 }
                 if state.format.is_none() {
-                    state.format = super::drm_fourcc_to_shm_format(format);
+                    state.format = super::drm_fourcc_to_pixel(format).map(super::pixel_to_shm);
                     if state.format.is_none() {
                         log::warn!(
                             "Unknown dmabuf DRM fourcc 0x{:08x}, falling back to Xrgb8888",

--- a/src/wayland_capture/wayland_events.rs
+++ b/src/wayland_capture/wayland_events.rs
@@ -294,14 +294,35 @@ impl Dispatch<ZwlrScreencopyFrameV1, Arc<Mutex<FrameState>>> for WaylandCapture 
                 width,
                 height,
             } => {
-                // TODO:Обработка LinuxDmabuf - альтернативный способ передачи данных
-                // Пока не поддерживаем, но логируем для отладки
-                log::debug!(
-                    "Received LinuxDmabuf: format={}, width={}, height={}",
-                    format,
-                    width,
-                    height
-                );
+                let mut state = match lock_frame_state(frame_state) {
+                    Ok(state) => state,
+                    Err(err) => {
+                        log::error!(
+                            "Dropping screencopy LinuxDmabuf event due to mutex error: {}",
+                            err
+                        );
+                        return;
+                    }
+                };
+                // Only take dimensions / format from dmabuf if the Buffer event
+                // hasn't already populated them (some compositors send both).
+                if state.width == 0 {
+                    state.width = width;
+                }
+                if state.height == 0 {
+                    state.height = height;
+                }
+                if state.format.is_none() {
+                    state.format = super::drm_fourcc_to_shm_format(format);
+                    if state.format.is_none() {
+                        log::warn!(
+                            "Unknown dmabuf DRM fourcc 0x{:08x}, falling back to Xrgb8888",
+                            format
+                        );
+                        state.format = Some(ShmFormat::Xrgb8888);
+                    }
+                }
+                state.linux_dmabuf_received = true;
             }
             Event::BufferDone => {
                 log::debug!("Buffer copy completed");

--- a/src/wayland_capture/wayland_events.rs
+++ b/src/wayland_capture/wayland_events.rs
@@ -40,6 +40,20 @@ impl Dispatch<WlRegistry, ()> for WaylandCapture {
                         }
                     }
                 }
+                "ext_output_image_capture_source_manager_v1" => {
+                    state.globals.ext_source_manager =
+                        Some(registry.bind::<ExtOutputImageCaptureSourceManagerV1, _, _>(
+                            name,
+                            version,
+                            qh,
+                            (),
+                        ));
+                }
+                "ext_image_copy_capture_manager_v1" => {
+                    state.globals.ext_copy_manager = Some(
+                        registry.bind::<ExtImageCopyCaptureManagerV1, _, _>(name, version, qh, ()),
+                    );
+                }
                 "wl_output" => {
                     let output = registry.bind::<WlOutput, _, _>(name, version, qh, ());
                     let output_id = output.id().protocol_id();
@@ -422,5 +436,115 @@ impl Dispatch<ZxdgOutputManagerV1, ()> for WaylandCapture {
         _conn: &Connection,
         _qh: &QueueHandle<Self>,
     ) {
+    }
+}
+
+impl Dispatch<ExtImageCaptureSourceV1, ()> for WaylandCapture {
+    fn event(
+        _state: &mut Self,
+        _proxy: &ExtImageCaptureSourceV1,
+        _event: <ExtImageCaptureSourceV1 as Proxy>::Event,
+        _data: &(),
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+    ) {
+    }
+}
+
+impl Dispatch<ExtOutputImageCaptureSourceManagerV1, ()> for WaylandCapture {
+    fn event(
+        _state: &mut Self,
+        _proxy: &ExtOutputImageCaptureSourceManagerV1,
+        _event: <ExtOutputImageCaptureSourceManagerV1 as Proxy>::Event,
+        _data: &(),
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+    ) {
+    }
+}
+
+impl Dispatch<ExtImageCopyCaptureManagerV1, ()> for WaylandCapture {
+    fn event(
+        _state: &mut Self,
+        _proxy: &ExtImageCopyCaptureManagerV1,
+        _event: <ExtImageCopyCaptureManagerV1 as Proxy>::Event,
+        _data: &(),
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+    ) {
+    }
+}
+
+impl Dispatch<ExtImageCopyCaptureSessionV1, Arc<Mutex<FrameState>>> for WaylandCapture {
+    fn event(
+        _state: &mut Self,
+        _session: &ExtImageCopyCaptureSessionV1,
+        event: <ExtImageCopyCaptureSessionV1 as Proxy>::Event,
+        frame_state: &Arc<Mutex<FrameState>>,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+    ) {
+        use wayland_protocols::ext::image_copy_capture::v1::client::ext_image_copy_capture_session_v1::Event;
+        let mut s = match lock_frame_state(frame_state) {
+            Ok(s) => s,
+            Err(err) => {
+                log::error!("Dropping ext session event due to mutex error: {}", err);
+                return;
+            }
+        };
+
+        match event {
+            Event::BufferSize { width, height } => {
+                s.width = width;
+                s.height = height;
+            }
+            Event::ShmFormat {
+                format: wayland_client::WEnum::Value(f),
+            } => {
+                s.format = Some(f);
+            }
+            Event::ShmFormat { .. } => {}
+            Event::Done => {
+                s.constraints_done = true;
+            }
+            Event::Stopped => {
+                log::warn!("Capture session stopped by compositor");
+                s.ready = true;
+            }
+            _ => {}
+        }
+    }
+}
+
+impl Dispatch<ExtImageCopyCaptureFrameV1, Arc<Mutex<FrameState>>> for WaylandCapture {
+    fn event(
+        _state: &mut Self,
+        frame: &ExtImageCopyCaptureFrameV1,
+        event: <ExtImageCopyCaptureFrameV1 as Proxy>::Event,
+        frame_state: &Arc<Mutex<FrameState>>,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+    ) {
+        use wayland_protocols::ext::image_copy_capture::v1::client::ext_image_copy_capture_frame_v1::Event;
+        let mut s = match lock_frame_state(frame_state) {
+            Ok(s) => s,
+            Err(err) => {
+                log::error!("Dropping ext frame event due to mutex error: {}", err);
+                return;
+            }
+        };
+
+        match event {
+            Event::Ready => {
+                s.ready = true;
+                frame.destroy();
+            }
+            Event::Failed { reason } => {
+                log::error!("Capture frame failed: reason={:?}", reason);
+                s.ready = true;
+                frame.destroy();
+            }
+            _ => {}
+        }
     }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,29 +1,6 @@
+use grim_rs::pixel_format::{self, PixelFormat};
 use grim_rs::{Backend, CaptureParameters, CaptureResult, Error, Grim, Region};
 use std::collections::HashMap;
-use wayland_client::protocol::wl_shm::Format as ShmFormat;
-
-fn convert_shm_to_rgba_for_test(buffer_data: &mut [u8], format: ShmFormat) {
-    match format {
-        ShmFormat::Xrgb8888 => {
-            for chunk in buffer_data.chunks_exact_mut(4) {
-                chunk.swap(0, 2);
-                chunk[3] = 255;
-            }
-        }
-        ShmFormat::Argb8888 => {
-            for chunk in buffer_data.chunks_exact_mut(4) {
-                chunk.swap(0, 2);
-            }
-        }
-        ShmFormat::Xbgr8888 => {
-            for chunk in buffer_data.chunks_exact_mut(4) {
-                chunk[3] = 255;
-            }
-        }
-        ShmFormat::Abgr8888 => {}
-        _ => {}
-    }
-}
 
 #[test]
 fn test_box_struct_creation() {
@@ -131,14 +108,14 @@ fn test_image_data_format() {
 #[test]
 fn test_convert_xrgb8888_to_rgba() {
     let mut pixel_data = vec![10, 20, 30, 99];
-    convert_shm_to_rgba_for_test(&mut pixel_data, ShmFormat::Xrgb8888);
+    pixel_format::convert_to_rgba(&mut pixel_data, PixelFormat::Xrgb8888);
     assert_eq!(pixel_data, vec![30, 20, 10, 255]);
 }
 
 #[test]
 fn test_convert_argb8888_to_rgba_preserves_alpha() {
     let mut pixel_data = vec![10, 20, 30, 40];
-    convert_shm_to_rgba_for_test(&mut pixel_data, ShmFormat::Argb8888);
+    pixel_format::convert_to_rgba(&mut pixel_data, PixelFormat::Argb8888);
     assert_eq!(pixel_data, vec![30, 20, 10, 40]);
 }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,4 +1,4 @@
-use grim_rs::{CaptureParameters, CaptureResult, Error, Grim, Region};
+use grim_rs::{Backend, CaptureParameters, CaptureResult, Error, Grim, Region};
 use std::collections::HashMap;
 use wayland_client::protocol::wl_shm::Format as ShmFormat;
 
@@ -38,13 +38,10 @@ fn test_box_struct_creation() {
 fn test_box_is_empty() {
     let box1 = Region::new(0, 0, 0, 0);
     assert!(box1.is_empty());
-
     let box2 = Region::new(0, 0, -10, 10);
     assert!(box2.is_empty());
-
     let box3 = Region::new(0, 0, 10, -5);
     assert!(box3.is_empty());
-
     let box4 = Region::new(0, 0, 10, 10);
     assert!(!box4.is_empty());
 }
@@ -53,14 +50,12 @@ fn test_box_is_empty() {
 fn test_box_intersection() {
     let box1 = Region::new(0, 0, 100, 100);
     let box2 = Region::new(50, 50, 100, 100);
-
     assert!(box1.intersects(&box2));
     let intersection = box1.intersection(&box2).unwrap();
     assert_eq!(intersection.x(), 50);
     assert_eq!(intersection.y(), 50);
     assert_eq!(intersection.width(), 50);
     assert_eq!(intersection.height(), 50);
-
     let box3 = Region::new(0, 0, 10, 10);
     let box4 = Region::new(100, 100, 10, 10);
     assert!(!box3.intersects(&box4));
@@ -82,7 +77,6 @@ fn test_box_string_parsing() {
 fn test_capture_result_struct() {
     let data = vec![255u8; 400];
     let result = CaptureResult::new(data, 10, 10);
-
     assert_eq!(result.width(), 10);
     assert_eq!(result.height(), 10);
     assert_eq!(result.data().len(), 400); // 10x10x4
@@ -94,7 +88,6 @@ fn test_capture_parameters_struct() {
         .region(Region::new(0, 0, 800, 600))
         .overlay_cursor(true)
         .scale(1.5);
-
     assert_eq!(params.output_name(), "eDP-1");
     assert_eq!(params.region_ref(), Some(&Region::new(0, 0, 800, 600)));
     assert!(params.overlay_cursor_enabled());
@@ -105,10 +98,8 @@ fn test_capture_parameters_struct() {
 fn test_error_messages() {
     let error = grim_rs::Error::InvalidGeometry("test".to_string());
     assert!(error.to_string().contains("Invalid geometry format"));
-
     let error = grim_rs::Error::NoOutputs;
     assert_eq!(error.to_string(), "No outputs available");
-
     let error = grim_rs::Error::OutputNotFound("test".to_string());
     assert!(error.to_string().contains("Output not found"));
 }
@@ -130,9 +121,7 @@ fn test_image_data_format() {
         0, 0, 255, 255, // Blue pixel
         255, 255, 255, 255, // White pixel
     ];
-
     assert_eq!(data.len(), (width * height * 4) as usize);
-
     assert_eq!(data[0], 255); // R
     assert_eq!(data[1], 0); // G
     assert_eq!(data[2], 0); // B
@@ -156,7 +145,6 @@ fn test_convert_argb8888_to_rgba_preserves_alpha() {
 #[test]
 fn test_png_compression_levels() {
     let test_data = vec![255u8; 100 * 100 * 4]; // 100x100 image
-
     if let Ok(grim) = Grim::new() {
         let _ = grim.to_png(&test_data, 100, 100);
         let _ = grim.to_png_with_compression(&test_data, 100, 100, 0);
@@ -168,7 +156,6 @@ fn test_png_compression_levels() {
 #[test]
 fn test_capture_parameters_default_behavior() {
     let params = CaptureParameters::new("test");
-
     assert_eq!(params.output_name(), "test");
     assert!(params.region_ref().is_none());
     assert!(!params.overlay_cursor_enabled());
@@ -179,11 +166,9 @@ fn test_capture_parameters_default_behavior() {
 #[test]
 fn test_jpeg_functionality_available() {
     let test_data = vec![255u8; 10 * 10 * 4];
-
     if let Ok(grim) = Grim::new() {
         let jpeg_result = grim.to_jpeg(&test_data, 10, 10);
         assert!(jpeg_result.is_ok());
-
         let jpeg_result_with_quality = grim.to_jpeg_with_quality(&test_data, 10, 10, 85);
         assert!(jpeg_result_with_quality.is_ok());
     }
@@ -193,7 +178,6 @@ fn test_jpeg_functionality_available() {
 #[test]
 fn test_jpeg_functionality_unavailable() {
     let test_data = vec![255u8; 10 * 10 * 4];
-
     match Grim::new() {
         Ok(grim) => {
             let jpeg_result = grim.to_jpeg(&test_data, 10, 10);
@@ -214,13 +198,10 @@ fn test_multi_output_capture_result() {
         "output2".to_string(),
         CaptureResult::new(vec![128u8; 200 * 150 * 4], 200, 150),
     );
-
     let multi_result = grim_rs::MultiOutputCaptureResult::new(outputs_map);
-
     assert_eq!(multi_result.outputs().len(), 2);
     assert!(multi_result.outputs().contains_key("output1"));
     assert!(multi_result.outputs().contains_key("output2"));
-
     let output1_result = multi_result.get("output1").unwrap();
     assert_eq!(output1_result.width(), 100);
     assert_eq!(output1_result.height(), 100);
@@ -230,11 +211,9 @@ fn test_multi_output_capture_result() {
 #[test]
 fn test_scale_functionality_validation() {
     let scales = [0.5, 1.0, 1.5, 2.0, 0.25];
-
     for scale in scales.iter() {
         let new_width = (800.0 * scale) as u32;
         let new_height = (600.0 * scale) as u32;
-
         assert!(new_width > 0);
         assert!(new_height > 0);
     }
@@ -244,10 +223,8 @@ fn test_scale_functionality_validation() {
 fn test_geometry_bounds_checking() {
     let invalid_box = Region::new(0, 0, -10, 100);
     assert!(invalid_box.is_empty());
-
     let invalid_box2 = Region::new(0, 0, 100, -10);
     assert!(invalid_box2.is_empty());
-
     let valid_box = Region::new(10, 10, 100, 100);
     assert!(!valid_box.is_empty());
 }
@@ -256,14 +233,12 @@ fn test_geometry_bounds_checking() {
 fn test_region_intersection_with_outputs() {
     let output_box = Region::new(0, 0, 1920, 1080);
     let capture_region = Region::new(100, 100, 500, 500);
-
     assert!(output_box.intersects(&capture_region));
     let intersection = output_box.intersection(&capture_region).unwrap();
     assert_eq!(intersection.x(), 100);
     assert_eq!(intersection.y(), 100);
     assert_eq!(intersection.width(), 500);
     assert_eq!(intersection.height(), 500);
-
     let region_outside = Region::new(2000, 2000, 100, 100);
     assert!(!output_box.intersects(&region_outside));
     assert!(output_box.intersection(&region_outside).is_none());
@@ -274,7 +249,6 @@ mod transform_tests {
     fn test_transform_normal() {
         let width = 1920;
         let height = 1080;
-
         assert_eq!(width, 1920);
         assert_eq!(height, 1080);
     }
@@ -284,10 +258,8 @@ mod transform_tests {
     fn test_transform_90_degree_rotation() {
         let original_width = 1920;
         let original_height = 1080;
-
         let expected_width = 1080;
         let expected_height = 1920;
-
         assert_ne!(original_width, expected_width);
         assert_ne!(original_height, expected_height);
         assert_eq!(original_width, expected_height);
@@ -299,7 +271,6 @@ mod transform_tests {
     fn test_transform_180_degree_rotation() {
         let width = 1920;
         let height = 1080;
-
         assert_eq!(width, 1920);
         assert_eq!(height, 1080);
     }
@@ -309,10 +280,8 @@ mod transform_tests {
     fn test_transform_270_degree_rotation() {
         let original_width = 1920;
         let original_height = 1080;
-
         let expected_width = 1080;
         let expected_height = 1920;
-
         assert_eq!(original_width, expected_height);
         assert_eq!(original_height, expected_width);
     }
@@ -322,7 +291,6 @@ mod transform_tests {
     fn test_transform_flipped() {
         let width = 1920;
         let height = 1080;
-
         assert_eq!(width, 1920);
         assert_eq!(height, 1080);
     }
@@ -332,10 +300,8 @@ mod transform_tests {
     fn test_transform_flipped_90() {
         let original_width = 1920;
         let original_height = 1080;
-
         let expected_width = 1080;
         let expected_height = 1920;
-
         assert_eq!(original_width, expected_height);
         assert_eq!(original_height, expected_width);
     }
@@ -348,7 +314,6 @@ mod transform_tests {
             height: i32,
             rotated: bool,
         }
-
         let outputs = [
             TestOutput {
                 width: 1920,
@@ -361,15 +326,12 @@ mod transform_tests {
                 rotated: true,
             },
         ];
-
         assert_eq!(outputs[0].width, 1920);
         assert_eq!(outputs[0].height, 1080);
         assert!(!outputs[0].rotated);
-
         assert_eq!(outputs[1].width, 1080);
         assert_eq!(outputs[1].height, 1920);
         assert!(outputs[1].rotated);
-
         assert_eq!(outputs[0].width, outputs[1].height);
         assert_eq!(outputs[0].height, outputs[1].width);
     }
@@ -380,16 +342,12 @@ mod transform_tests {
         let physical_width = 3840;
         let physical_height = 2160;
         let scale = 2;
-
         let logical_width = physical_width / scale;
         let logical_height = physical_height / scale;
-
         assert_eq!(logical_width, 1920);
         assert_eq!(logical_height, 1080);
-
         let logical_width_rotated = logical_height;
         let logical_height_rotated = logical_width;
-
         assert_eq!(logical_width_rotated, 1080);
         assert_eq!(logical_height_rotated, 1920);
     }
@@ -399,10 +357,8 @@ mod transform_tests {
     fn test_transform_integration_dimensions() {
         let original_width = 1920;
         let original_height = 1080;
-
         let rotated_width = 1080;
         let rotated_height = 1920;
-
         assert_eq!(original_width, rotated_height);
         assert_eq!(original_height, rotated_width);
     }
@@ -416,7 +372,6 @@ mod transform_tests {
             0, 0, 255, 255, // Blue
             255, 255, 255, 255, // White
         ];
-
         assert_eq!(test_data.len(), 2 * 2 * 4);
     }
 
@@ -425,10 +380,8 @@ mod transform_tests {
     fn test_flipped_transforms_dimensions() {
         let width = 1920;
         let height = 1080;
-
         assert_eq!(width, 1920);
         assert_eq!(height, 1080);
-
         assert_eq!(width, 1920);
         assert_eq!(height, 1080);
     }
@@ -437,11 +390,9 @@ mod transform_tests {
     #[test]
     fn test_rotation_angles() {
         use std::f64::consts::{FRAC_PI_2, PI};
-
         let angle_90 = FRAC_PI_2; // π/2
         let angle_180 = PI; // π
         let angle_270 = 3.0 * FRAC_PI_2; // 3π/2
-
         assert!(angle_90 > 0.0 && angle_90 < PI);
         assert_eq!(angle_180, PI);
         assert!(angle_270 > PI && angle_270 < 2.0 * PI);
@@ -462,13 +413,10 @@ mod y_invert_tests {
     #[test]
     fn test_y_invert_flag_detection() {
         const Y_INVERT: u32 = 1;
-
         let flags_with_invert = 1u32;
         assert_ne!(flags_with_invert & Y_INVERT, 0);
-
         let flags_without_invert = 0u32;
         assert_eq!(flags_without_invert & Y_INVERT, 0);
-
         let flags_mixed = 3u32;
         assert_ne!(flags_mixed & Y_INVERT, 0);
     }
@@ -478,7 +426,6 @@ mod y_invert_tests {
     fn test_y_invert_preserves_dimensions() {
         let width = 1920;
         let height = 1080;
-
         assert_eq!(width, 1920);
         assert_eq!(height, 1080);
     }
@@ -488,18 +435,14 @@ mod y_invert_tests {
     fn test_y_invert_with_transform() {
         let _original_width = 1920;
         let _original_height = 1080;
-
         let transformed_width = 1080;
         let transformed_height = 1920;
-
         let final_width = transformed_width;
         let final_height = transformed_height;
-
         assert_eq!(final_width, 1080);
         assert_eq!(final_height, 1920);
     }
 
-    /// Test FrameState flags field
     #[test]
     fn test_frame_state_flags_field() {
         let flags: u32 = 0;
@@ -582,4 +525,85 @@ fn test_scale_functionality() {
         Err(Error::NoOutputs) => {}
         Err(e) => panic!("Unexpected error: {:?}", e),
     }
+}
+
+#[test]
+fn test_backend_enum_variants() {
+    let auto = Backend::Auto;
+    let ext = Backend::ExtImageCopyCapture;
+    let wlr = Backend::WlrScreencopy;
+    assert_ne!(auto, ext);
+    assert_ne!(ext, wlr);
+    assert_eq!(auto, Backend::Auto);
+    // Auto is the default-like variant
+    assert!(matches!(auto, Backend::Auto));
+}
+
+#[test]
+fn test_new_ext_constructor() {
+    match Grim::new_ext() {
+        Ok(_) => {}
+        Err(e) => {
+            assert!(
+                e.to_string().contains("not available"),
+                "expected UnsupportedProtocol, got: {e}"
+            );
+        }
+    }
+}
+
+#[test]
+fn test_new_wlr_constructor() {
+    match Grim::new_wlr() {
+        Ok(_) => {}
+        Err(e) => {
+            assert!(
+                e.to_string().contains("not available"),
+                "expected UnsupportedProtocol, got: {e}"
+            );
+        }
+    }
+}
+
+#[test]
+fn test_new_auto_is_equivalent_to_new() {
+    let result_auto = Grim::new();
+    match result_auto {
+        Ok(_) | Err(Error::NoOutputs) => {} // expected
+        Err(e) => panic!("Unexpected error from Grim::new(): {e}"),
+    }
+}
+
+#[test]
+fn test_new_ext_can_capture() {
+    if let Ok(mut grim) = Grim::new_ext() {
+        match grim.capture_all() {
+            Ok(result) => {
+                assert_eq!(
+                    result.data().len(),
+                    (result.width() * result.height() * 4) as usize
+                );
+            }
+            Err(Error::NoOutputs) => {} // no monitors connected
+            Err(e) => panic!("Capture failed on ext backend: {e}"),
+        }
+    }
+    // ext not available — skip
+}
+
+#[test]
+fn test_new_wlr_can_capture() {
+    if let Ok(mut grim) = Grim::new_wlr() {
+        match grim.capture_all() {
+            Ok(result) => {
+                assert_eq!(
+                    result.data().len(),
+                    (result.width() * result.height() * 4) as usize
+                );
+            }
+            Err(Error::NoOutputs) => {} // no monitors connected
+            Err(e) => panic!("Capture failed on wlr backend: {e}"),
+        }
+    }
+    // wlr not available — skip
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,4 +1,4 @@
-use grim_rs::{Box as GrimBox, CaptureParameters, CaptureResult, Error, Grim};
+use grim_rs::{CaptureParameters, CaptureResult, Error, Grim, Region};
 use std::collections::HashMap;
 use wayland_client::protocol::wl_shm::Format as ShmFormat;
 
@@ -27,7 +27,7 @@ fn convert_shm_to_rgba_for_test(buffer_data: &mut [u8], format: ShmFormat) {
 
 #[test]
 fn test_box_struct_creation() {
-    let box1 = GrimBox::new(10, 20, 100, 200);
+    let box1 = Region::new(10, 20, 100, 200);
     assert_eq!(box1.x(), 10);
     assert_eq!(box1.y(), 20);
     assert_eq!(box1.width(), 100);
@@ -36,23 +36,23 @@ fn test_box_struct_creation() {
 
 #[test]
 fn test_box_is_empty() {
-    let box1 = GrimBox::new(0, 0, 0, 0);
+    let box1 = Region::new(0, 0, 0, 0);
     assert!(box1.is_empty());
 
-    let box2 = GrimBox::new(0, 0, -10, 10);
+    let box2 = Region::new(0, 0, -10, 10);
     assert!(box2.is_empty());
 
-    let box3 = GrimBox::new(0, 0, 10, -5);
+    let box3 = Region::new(0, 0, 10, -5);
     assert!(box3.is_empty());
 
-    let box4 = GrimBox::new(0, 0, 10, 10);
+    let box4 = Region::new(0, 0, 10, 10);
     assert!(!box4.is_empty());
 }
 
 #[test]
 fn test_box_intersection() {
-    let box1 = GrimBox::new(0, 0, 100, 100);
-    let box2 = GrimBox::new(50, 50, 100, 100);
+    let box1 = Region::new(0, 0, 100, 100);
+    let box2 = Region::new(50, 50, 100, 100);
 
     assert!(box1.intersects(&box2));
     let intersection = box1.intersection(&box2).unwrap();
@@ -61,8 +61,8 @@ fn test_box_intersection() {
     assert_eq!(intersection.width(), 50);
     assert_eq!(intersection.height(), 50);
 
-    let box3 = GrimBox::new(0, 0, 10, 10);
-    let box4 = GrimBox::new(100, 100, 10, 10);
+    let box3 = Region::new(0, 0, 10, 10);
+    let box4 = Region::new(100, 100, 10, 10);
     assert!(!box3.intersects(&box4));
     assert!(box3.intersection(&box4).is_none());
 }
@@ -70,7 +70,7 @@ fn test_box_intersection() {
 #[test]
 fn test_box_string_parsing() {
     let box_str = "10,20 300x400";
-    let parsed: GrimBox = box_str.parse().unwrap();
+    let parsed: Region = box_str.parse().unwrap();
     assert_eq!(parsed.x(), 10);
     assert_eq!(parsed.y(), 20);
     assert_eq!(parsed.width(), 300);
@@ -91,12 +91,12 @@ fn test_capture_result_struct() {
 #[test]
 fn test_capture_parameters_struct() {
     let params = CaptureParameters::new("eDP-1")
-        .region(GrimBox::new(0, 0, 800, 600))
+        .region(Region::new(0, 0, 800, 600))
         .overlay_cursor(true)
         .scale(1.5);
 
     assert_eq!(params.output_name(), "eDP-1");
-    assert_eq!(params.region_ref(), Some(&GrimBox::new(0, 0, 800, 600)));
+    assert_eq!(params.region_ref(), Some(&Region::new(0, 0, 800, 600)));
     assert!(params.overlay_cursor_enabled());
     assert_eq!(params.scale_factor(), Some(1.5));
 }
@@ -115,7 +115,7 @@ fn test_error_messages() {
 
 #[test]
 fn test_crate_export_structs() {
-    let _box = GrimBox::new(0, 0, 100, 100);
+    let _box = Region::new(0, 0, 100, 100);
     let _params = CaptureParameters::new("test");
     let _result = CaptureResult::new(vec![], 0, 0);
 }
@@ -242,20 +242,20 @@ fn test_scale_functionality_validation() {
 
 #[test]
 fn test_geometry_bounds_checking() {
-    let invalid_box = GrimBox::new(0, 0, -10, 100);
+    let invalid_box = Region::new(0, 0, -10, 100);
     assert!(invalid_box.is_empty());
 
-    let invalid_box2 = GrimBox::new(0, 0, 100, -10);
+    let invalid_box2 = Region::new(0, 0, 100, -10);
     assert!(invalid_box2.is_empty());
 
-    let valid_box = GrimBox::new(10, 10, 100, 100);
+    let valid_box = Region::new(10, 10, 100, 100);
     assert!(!valid_box.is_empty());
 }
 
 #[test]
 fn test_region_intersection_with_outputs() {
-    let output_box = GrimBox::new(0, 0, 1920, 1080);
-    let capture_region = GrimBox::new(100, 100, 500, 500);
+    let output_box = Region::new(0, 0, 1920, 1080);
+    let capture_region = Region::new(100, 100, 500, 500);
 
     assert!(output_box.intersects(&capture_region));
     let intersection = output_box.intersection(&capture_region).unwrap();
@@ -264,7 +264,7 @@ fn test_region_intersection_with_outputs() {
     assert_eq!(intersection.width(), 500);
     assert_eq!(intersection.height(), 500);
 
-    let region_outside = GrimBox::new(2000, 2000, 100, 100);
+    let region_outside = Region::new(2000, 2000, 100, 100);
     assert!(!output_box.intersects(&region_outside));
     assert!(output_box.intersection(&region_outside).is_none());
 }
@@ -564,7 +564,7 @@ fn test_jpeg_disabled() {
 #[test]
 fn test_read_region_from_stdin() {
     let region_str = "10,20 300x400";
-    let result: std::result::Result<GrimBox, _> = region_str.parse();
+    let result: std::result::Result<Region, _> = region_str.parse();
     assert!(result.is_ok());
     let region = result.unwrap();
     assert_eq!(region.x(), 10);

--- a/tests/test_encapsulation.rs
+++ b/tests/test_encapsulation.rs
@@ -1,10 +1,10 @@
-use grim_rs::geometry::Box;
+use grim_rs::geometry::Region;
 use grim_rs::{CaptureParameters, CaptureResult, MultiOutputCaptureResult};
 use std::collections::HashMap;
 
 #[test]
 fn box_getters_work_correctly() {
-    let b = Box::new(10, 20, 300, 400);
+    let b = Region::new(10, 20, 300, 400);
 
     assert_eq!(b.x(), 10);
     assert_eq!(b.y(), 20);
@@ -35,7 +35,7 @@ fn capture_result_into_data_consumes() {
 
 #[test]
 fn capture_parameters_builder_pattern_works() {
-    let region = Box::new(0, 0, 100, 100);
+    let region = Region::new(0, 0, 100, 100);
 
     let params = CaptureParameters::new("HDMI-A-1")
         .region(region)
@@ -60,7 +60,7 @@ fn capture_parameters_minimal_construction() {
 
 #[test]
 fn capture_parameters_builder_is_chainable() {
-    let region = Box::new(10, 20, 640, 480);
+    let region = Region::new(10, 20, 640, 480);
 
     let params = CaptureParameters::new("DP-1")
         .region(region)
@@ -153,7 +153,7 @@ fn capture_result_data_returns_slice() {
 
 #[test]
 fn box_encapsulation_prevents_direct_field_access() {
-    let b = Box::new(100, 200, 300, 400);
+    let b = Region::new(100, 200, 300, 400);
 
     assert_eq!(b.x(), 100);
     assert_eq!(b.y(), 200);

--- a/tests/test_geometry.rs
+++ b/tests/test_geometry.rs
@@ -1,9 +1,9 @@
-use grim_rs::Box;
+use grim_rs::Region;
 
 #[test]
 fn test_box_parsing() {
     let box_str = "10,20 300x400";
-    let parsed: Box = match box_str.parse() {
+    let parsed: Region = match box_str.parse() {
         Ok(value) => value,
         Err(err) => panic!("unexpected parse error: {err}"),
     };
@@ -15,8 +15,8 @@ fn test_box_parsing() {
 
 #[test]
 fn test_box_intersection() {
-    let box1 = Box::new(0, 0, 100, 100);
-    let box2 = Box::new(50, 50, 100, 100);
+    let box1 = Region::new(0, 0, 100, 100);
+    let box2 = Region::new(50, 50, 100, 100);
 
     assert!(box1.intersects(&box2));
 
@@ -32,7 +32,7 @@ fn test_box_intersection() {
 
 #[test]
 fn test_geometry_parsing() {
-    let geometry: Box = "100,200 800x600".parse().unwrap();
+    let geometry: Region = "100,200 800x600".parse().unwrap();
     assert_eq!(geometry.x(), 100);
     assert_eq!(geometry.y(), 200);
     assert_eq!(geometry.width(), 800);

--- a/tests/test_geometry_properties.rs
+++ b/tests/test_geometry_properties.rs
@@ -1,11 +1,11 @@
-use grim_rs::geometry::Box;
+use grim_rs::geometry::Region;
 use proptest::prelude::*;
 
 proptest! {
     #[test]
     fn box_getters_match_construction(x in -10000i32..10000, y in -10000i32..10000,
                                        w in 0i32..10000, h in 0i32..10000) {
-        let b = Box::new(x, y, w, h);
+        let b = Region::new(x, y, w, h);
         prop_assert_eq!(b.x(), x);
         prop_assert_eq!(b.y(), y);
         prop_assert_eq!(b.width(), w);
@@ -15,7 +15,7 @@ proptest! {
     #[test]
     fn box_is_empty_iff_zero_area(x in -1000i32..1000, y in -1000i32..1000,
                                    w in -100i32..100, h in -100i32..100) {
-        let b = Box::new(x, y, w, h);
+        let b = Region::new(x, y, w, h);
         let expected_empty = w <= 0 || h <= 0;
         prop_assert_eq!(b.is_empty(), expected_empty);
     }
@@ -25,8 +25,8 @@ proptest! {
         x1 in -1000i32..1000, y1 in -1000i32..1000, w1 in 1i32..500, h1 in 1i32..500,
         x2 in -1000i32..1000, y2 in -1000i32..1000, w2 in 1i32..500, h2 in 1i32..500
     ) {
-        let box1 = Box::new(x1, y1, w1, h1);
-        let box2 = Box::new(x2, y2, w2, h2);
+        let box1 = Region::new(x1, y1, w1, h1);
+        let box2 = Region::new(x2, y2, w2, h2);
 
         let int1 = box1.intersection(&box2);
         let int2 = box2.intersection(&box1);
@@ -39,8 +39,8 @@ proptest! {
         x1 in -1000i32..1000, y1 in -1000i32..1000, w1 in 1i32..500, h1 in 1i32..500,
         x2 in -1000i32..1000, y2 in -1000i32..1000, w2 in 1i32..500, h2 in 1i32..500
     ) {
-        let box1 = Box::new(x1, y1, w1, h1);
-        let box2 = Box::new(x2, y2, w2, h2);
+        let box1 = Region::new(x1, y1, w1, h1);
+        let box2 = Region::new(x2, y2, w2, h2);
 
         prop_assert_eq!(
             box1.intersects(&box2),
@@ -54,8 +54,8 @@ proptest! {
         x1 in -1000i32..1000, y1 in -1000i32..1000, w1 in 1i32..500, h1 in 1i32..500,
         x2 in -1000i32..1000, y2 in -1000i32..1000, w2 in 1i32..500, h2 in 1i32..500
     ) {
-        let box1 = Box::new(x1, y1, w1, h1);
-        let box2 = Box::new(x2, y2, w2, h2);
+        let box1 = Region::new(x1, y1, w1, h1);
+        let box2 = Region::new(x2, y2, w2, h2);
 
         let has_intersection = box1.intersection(&box2).is_some();
         let intersects = box1.intersects(&box2);
@@ -72,8 +72,8 @@ proptest! {
         x1 in -1000i32..1000, y1 in -1000i32..1000, w1 in 1i32..500, h1 in 1i32..500,
         x2 in -1000i32..1000, y2 in -1000i32..1000, w2 in 1i32..500, h2 in 1i32..500
     ) {
-        let box1 = Box::new(x1, y1, w1, h1);
-        let box2 = Box::new(x2, y2, w2, h2);
+        let box1 = Region::new(x1, y1, w1, h1);
+        let box2 = Region::new(x2, y2, w2, h2);
 
         if let Some(intersection) = box1.intersection(&box2) {
             prop_assert!(
@@ -97,7 +97,7 @@ proptest! {
     #[test]
     fn box_with_self_returns_self(x in -1000i32..1000, y in -1000i32..1000,
                                    w in 1i32..500, h in 1i32..500) {
-        let b = Box::new(x, y, w, h);
+        let b = Region::new(x, y, w, h);
         let intersection = b.intersection(&b);
 
         prop_assert_eq!(intersection, Some(b), "Box intersected with itself should return itself");
@@ -108,9 +108,9 @@ proptest! {
         x1 in -1000i32..1000, y1 in -1000i32..1000,
         x2 in -1000i32..1000, y2 in -1000i32..1000
     ) {
-        let empty1 = Box::new(x1, y1, 0, 0);
-        let empty2 = Box::new(x2, y2, 0, 100);
-        let empty3 = Box::new(x2, y2, 100, 0);
+        let empty1 = Region::new(x1, y1, 0, 0);
+        let empty2 = Region::new(x2, y2, 0, 100);
+        let empty3 = Region::new(x2, y2, 100, 0);
 
         prop_assert!(!empty1.intersects(&empty2), "Empty boxes should not intersect");
         prop_assert!(!empty2.intersects(&empty3), "Empty boxes should not intersect");
@@ -121,9 +121,9 @@ proptest! {
     #[test]
     fn parse_and_display_roundtrip(x in -1000i32..1000, y in -1000i32..1000,
                                      w in 0i32..500, h in 0i32..500) {
-        let original = Box::new(x, y, w, h);
+        let original = Region::new(x, y, w, h);
         let serialized = original.to_string();
-        let parsed: Box = serialized.parse().unwrap();
+        let parsed: Region = serialized.parse().unwrap();
 
         prop_assert_eq!(parsed, original, "Parsing should be inverse of Display");
     }
@@ -135,8 +135,8 @@ mod unit_tests {
 
     #[test]
     fn non_overlapping_boxes_dont_intersect() {
-        let box1 = Box::new(0, 0, 10, 10);
-        let box2 = Box::new(20, 20, 10, 10);
+        let box1 = Region::new(0, 0, 10, 10);
+        let box2 = Region::new(20, 20, 10, 10);
 
         assert!(!box1.intersects(&box2));
         assert_eq!(box1.intersection(&box2), None);
@@ -144,8 +144,8 @@ mod unit_tests {
 
     #[test]
     fn adjacent_boxes_dont_intersect() {
-        let box1 = Box::new(0, 0, 10, 10);
-        let box2 = Box::new(10, 0, 10, 10);
+        let box1 = Region::new(0, 0, 10, 10);
+        let box2 = Region::new(10, 0, 10, 10);
 
         assert!(!box1.intersects(&box2));
         assert_eq!(box1.intersection(&box2), None);
@@ -153,8 +153,8 @@ mod unit_tests {
 
     #[test]
     fn contained_box_intersection_is_smaller_box() {
-        let outer = Box::new(0, 0, 100, 100);
-        let inner = Box::new(25, 25, 50, 50);
+        let outer = Region::new(0, 0, 100, 100);
+        let inner = Region::new(25, 25, 50, 50);
 
         assert!(outer.intersects(&inner));
         let intersection = outer.intersection(&inner).unwrap();
@@ -163,9 +163,9 @@ mod unit_tests {
 
     #[test]
     fn negative_dimensions_are_empty() {
-        let box1 = Box::new(0, 0, -10, 10);
-        let box2 = Box::new(0, 0, 10, -10);
-        let box3 = Box::new(0, 0, -10, -10);
+        let box1 = Region::new(0, 0, -10, 10);
+        let box2 = Region::new(0, 0, 10, -10);
+        let box3 = Region::new(0, 0, -10, -10);
 
         assert!(box1.is_empty());
         assert!(box2.is_empty());

--- a/tests/test_grid_aligned.rs
+++ b/tests/test_grid_aligned.rs
@@ -1,13 +1,13 @@
 /// Tests for grid-aligned compositing optimization
 /// These tests verify the detection logic for grid-aligned layouts,
 /// which allows for optimized SRC-mode compositing instead of slower OVER mode.
-use grim_rs::Box;
+use grim_rs::Region;
 
 #[test]
 fn test_box_no_overlap() {
     // Two boxes side by side (no overlap) - grid-aligned
-    let box1 = Box::new(0, 0, 100, 100);
-    let box2 = Box::new(100, 0, 100, 100);
+    let box1 = Region::new(0, 0, 100, 100);
+    let box2 = Region::new(100, 0, 100, 100);
 
     assert!(
         !box1.intersects(&box2),
@@ -18,8 +18,8 @@ fn test_box_no_overlap() {
 #[test]
 fn test_box_with_overlap() {
     // Two boxes with overlap - NOT grid-aligned
-    let box1 = Box::new(0, 0, 100, 100);
-    let box2 = Box::new(50, 50, 100, 100);
+    let box1 = Region::new(0, 0, 100, 100);
+    let box2 = Region::new(50, 50, 100, 100);
 
     assert!(box1.intersects(&box2), "Overlapping boxes should intersect");
 
@@ -33,8 +33,8 @@ fn test_box_with_overlap() {
 #[test]
 fn test_grid_aligned_horizontal_layout() {
     // Two monitors side by side horizontally: [1920x1080] [1920x1080]
-    let box1 = Box::new(0, 0, 1920, 1080);
-    let box2 = Box::new(1920, 0, 1920, 1080);
+    let box1 = Region::new(0, 0, 1920, 1080);
+    let box2 = Region::new(1920, 0, 1920, 1080);
 
     assert!(
         !box1.intersects(&box2),
@@ -45,8 +45,8 @@ fn test_grid_aligned_horizontal_layout() {
 #[test]
 fn test_grid_aligned_vertical_layout() {
     // Two monitors stacked vertically
-    let box1 = Box::new(0, 0, 1920, 1080);
-    let box2 = Box::new(0, 1080, 1920, 1080);
+    let box1 = Region::new(0, 0, 1920, 1080);
+    let box2 = Region::new(0, 1080, 1920, 1080);
 
     assert!(
         !box1.intersects(&box2),
@@ -59,9 +59,9 @@ fn test_grid_aligned_l_shape_layout() {
     // L-shaped layout (common in multi-monitor setups)
     // [1920x1080]
     // [1920x1080][1920x1080]
-    let box1 = Box::new(0, 0, 1920, 1080); // Top
-    let box2 = Box::new(0, 1080, 1920, 1080); // Bottom-left
-    let box3 = Box::new(1920, 1080, 1920, 1080); // Bottom-right
+    let box1 = Region::new(0, 0, 1920, 1080); // Top
+    let box2 = Region::new(0, 1080, 1920, 1080); // Bottom-left
+    let box3 = Region::new(1920, 1080, 1920, 1080); // Bottom-right
 
     assert!(
         !box1.intersects(&box2),
@@ -79,8 +79,8 @@ fn test_grid_aligned_l_shape_layout() {
 
 #[test]
 fn test_non_grid_aligned_overlapping_monitors() {
-    let box1 = Box::new(0, 0, 1920, 1080);
-    let box2 = Box::new(1800, 0, 1920, 1080); // 120px overlap
+    let box1 = Region::new(0, 0, 1920, 1080);
+    let box2 = Region::new(1800, 0, 1920, 1080); // 120px overlap
 
     assert!(
         box1.intersects(&box2),
@@ -90,9 +90,9 @@ fn test_non_grid_aligned_overlapping_monitors() {
 
 #[test]
 fn test_grid_aligned_triple_monitor() {
-    let box_a = Box::new(0, 0, 1920, 1080);
-    let box_b = Box::new(1920, 0, 1920, 1080);
-    let box_c = Box::new(3840, 0, 1920, 1080);
+    let box_a = Region::new(0, 0, 1920, 1080);
+    let box_b = Region::new(1920, 0, 1920, 1080);
+    let box_c = Region::new(3840, 0, 1920, 1080);
 
     assert!(
         !box_a.intersects(&box_b),
@@ -112,8 +112,8 @@ fn test_grid_aligned_triple_monitor() {
 fn test_grid_aligned_different_sizes() {
     // Different size monitors but still grid-aligned
     // [2560x1440] [1920x1080]
-    let box1 = Box::new(0, 0, 2560, 1440);
-    let box2 = Box::new(2560, 0, 1920, 1080);
+    let box1 = Region::new(0, 0, 2560, 1440);
+    let box2 = Region::new(2560, 0, 1920, 1080);
 
     assert!(
         !box1.intersects(&box2),
@@ -123,8 +123,8 @@ fn test_grid_aligned_different_sizes() {
 
 #[test]
 fn test_region_intersection_within_output() {
-    let output = Box::new(0, 0, 1920, 1080);
-    let region = Box::new(100, 100, 800, 600);
+    let output = Region::new(0, 0, 1920, 1080);
+    let region = Region::new(100, 100, 800, 600);
 
     assert!(output.intersects(&region), "Region should be within output");
 
@@ -134,9 +134,9 @@ fn test_region_intersection_within_output() {
 
 #[test]
 fn test_region_spanning_multiple_outputs() {
-    let output1 = Box::new(0, 0, 1920, 1080);
-    let output2 = Box::new(1920, 0, 1920, 1080);
-    let region = Box::new(1800, 400, 240, 280);
+    let output1 = Region::new(0, 0, 1920, 1080);
+    let output2 = Region::new(1920, 0, 1920, 1080);
+    let region = Region::new(1800, 400, 240, 280);
 
     assert!(
         output1.intersects(&region),
@@ -161,8 +161,8 @@ fn test_region_spanning_multiple_outputs() {
 
 #[test]
 fn test_pixel_alignment_check() {
-    let box1 = Box::new(0, 0, 1920, 1080);
-    let box2 = Box::new(1920, 0, 1920, 1080);
+    let box1 = Region::new(0, 0, 1920, 1080);
+    let box2 = Region::new(1920, 0, 1920, 1080);
 
     assert_eq!(box1.x() + box1.width(), 1920);
     assert_eq!(box2.x(), 1920);
@@ -172,8 +172,8 @@ fn test_pixel_alignment_check() {
 
 #[test]
 fn test_empty_box_no_intersection() {
-    let box1 = Box::new(0, 0, 100, 100);
-    let box2 = Box::new(0, 0, 0, 0); // Empty box
+    let box1 = Region::new(0, 0, 100, 100);
+    let box2 = Region::new(0, 0, 0, 0); // Empty box
 
     assert!(!box1.intersects(&box2), "Empty box should not intersect");
     assert!(box2.is_empty(), "Box with zero dimensions should be empty");

--- a/tests/test_pixel_format.rs
+++ b/tests/test_pixel_format.rs
@@ -1,0 +1,80 @@
+use grim_rs::pixel_format::{self, PixelFormat};
+
+#[test]
+fn fourcc_known_mappings() {
+    assert_eq!(
+        pixel_format::fourcc_to_format(0x34325241),
+        Some(PixelFormat::Argb8888)
+    );
+    assert_eq!(
+        pixel_format::fourcc_to_format(0x34325258),
+        Some(PixelFormat::Xrgb8888)
+    );
+    assert_eq!(
+        pixel_format::fourcc_to_format(0x34324241),
+        Some(PixelFormat::Abgr8888)
+    );
+    assert_eq!(
+        pixel_format::fourcc_to_format(0x34324258),
+        Some(PixelFormat::Xbgr8888)
+    );
+}
+
+#[test]
+fn fourcc_unknown_returns_none() {
+    assert_eq!(pixel_format::fourcc_to_format(0xDEADBEEF), None);
+}
+
+#[test]
+fn convert_xrgb8888_swaps_and_fills_alpha() {
+    let mut data = vec![0x0A, 0x14, 0x1E, 0x63]; // B, G, R, X
+    pixel_format::convert_to_rgba(&mut data, PixelFormat::Xrgb8888);
+    assert_eq!(data, vec![0x1E, 0x14, 0x0A, 0xFF]); // R, G, B, 255
+}
+
+#[test]
+fn convert_argb8888_swaps_preserving_alpha() {
+    let mut data = vec![0x0A, 0x14, 0x1E, 0x63]; // B, G, R, A
+    pixel_format::convert_to_rgba(&mut data, PixelFormat::Argb8888);
+    assert_eq!(data, vec![0x1E, 0x14, 0x0A, 0x63]); // R, G, B, A
+}
+
+#[test]
+fn convert_xbgr8888_fills_alpha_no_swap() {
+    let mut data = vec![0x1E, 0x14, 0x0A, 0x00]; // R, G, B, X
+    pixel_format::convert_to_rgba(&mut data, PixelFormat::Xbgr8888);
+    assert_eq!(data, vec![0x1E, 0x14, 0x0A, 0xFF]); // R, G, B, 255
+}
+
+#[test]
+fn convert_abgr8888_is_noop() {
+    let original = vec![0x1E, 0x14, 0x0A, 0x63]; // R, G, B, A
+    let mut data = original.clone();
+    pixel_format::convert_to_rgba(&mut data, PixelFormat::Abgr8888);
+    assert_eq!(data, original);
+}
+
+#[test]
+fn convert_empty_buffer_is_noop() {
+    let mut data: Vec<u8> = vec![];
+    pixel_format::convert_to_rgba(&mut data, PixelFormat::Xrgb8888);
+    assert!(data.is_empty());
+}
+
+#[test]
+fn convert_incomplete_chunk_ignores_trailing_bytes() {
+    let mut data = vec![1, 2, 3]; // 3 bytes, not divisible by 4
+    pixel_format::convert_to_rgba(&mut data, PixelFormat::Argb8888);
+    assert_eq!(data, vec![1, 2, 3]); // unchanged
+}
+
+#[test]
+fn convert_multiple_pixels() {
+    // Two pixels: BGRA(10,20,30,40) + BGRA(50,60,70,80)
+    let mut data = vec![0x0A, 0x14, 0x1E, 0x28, 0x32, 0x3C, 0x46, 0x50];
+    pixel_format::convert_to_rgba(&mut data, PixelFormat::Argb8888);
+    assert_eq!(
+        data,
+        vec![0x1E, 0x14, 0x0A, 0x28, 0x46, 0x3C, 0x32, 0x50] // RGBA x2
+    );
+}

--- a/tests/test_rotated_output_semantics.rs
+++ b/tests/test_rotated_output_semantics.rs
@@ -1,9 +1,9 @@
-use grim_rs::Box;
+use grim_rs::Region;
 
 #[test]
 fn rotated_output_full_capture_uses_logical_dimensions() {
-    let logical_region = Box::new(0, 0, 1080, 1920);
-    let old_physical_region = Box::new(0, 0, 1920, 1080);
+    let logical_region = Region::new(0, 0, 1080, 1920);
+    let old_physical_region = Region::new(0, 0, 1920, 1080);
 
     assert_eq!(logical_region.width(), 1080);
     assert_eq!(logical_region.height(), 1920);
@@ -12,30 +12,30 @@ fn rotated_output_full_capture_uses_logical_dimensions() {
 
 #[test]
 fn rotated_output_multi_capture_defaults_to_local_logical_origin() {
-    let local_logical_region = Box::new(0, 0, 1080, 1920);
-    let old_global_physical_region = Box::new(3440, 0, 1920, 1080);
+    let local_logical_region = Region::new(0, 0, 1080, 1920);
+    let old_global_physical_region = Region::new(3440, 0, 1920, 1080);
 
-    assert_eq!(local_logical_region, Box::new(0, 0, 1080, 1920));
-    assert_eq!(old_global_physical_region, Box::new(3440, 0, 1920, 1080));
+    assert_eq!(local_logical_region, Region::new(0, 0, 1080, 1920));
+    assert_eq!(old_global_physical_region, Region::new(3440, 0, 1920, 1080));
     assert_ne!(local_logical_region, old_global_physical_region);
 }
 
 #[test]
 fn rotated_output_region_requests_stay_in_logical_space_even_with_scale() {
-    let output_box = Box::new(3440, 0, 1080, 1920);
-    let region = Box::new(3300, 0, 300, 1400);
+    let output_box = Region::new(3440, 0, 1080, 1920);
+    let region = Region::new(3300, 0, 300, 1400);
     let intersection = output_box.intersection(&region).unwrap();
 
-    let requested_region = Box::new(
+    let requested_region = Region::new(
         intersection.x() - output_box.x(),
         intersection.y() - output_box.y(),
         intersection.width(),
         intersection.height(),
     );
 
-    let old_physical_region = Box::new(0, 0, 320, 2160);
+    let old_physical_region = Region::new(0, 0, 320, 2160);
 
-    assert_eq!(requested_region, Box::new(0, 0, 160, 1400));
-    assert_eq!(old_physical_region, Box::new(0, 0, 320, 2160));
+    assert_eq!(requested_region, Region::new(0, 0, 160, 1400));
+    assert_eq!(old_physical_region, Region::new(0, 0, 320, 2160));
     assert_ne!(requested_region, old_physical_region);
 }


### PR DESCRIPTION
#### 2026/05/14 - [handle zwlr_screencopy linux_dmabuf frames](https://github.com/shikoucore/grim-rs/commit/5681802b0a927fc8d654ce9afc70489beb621f04)
#### 2026/05/15 -  [support ext-image-copy-capture](https://github.com/shikoucore/grim-rs/pull/18/commits/d5daf81443937fd782db3d0b5d12e17dce0d631e)
#### 2026/05/16 - [expose RGBA conversion utilities](https://github.com/shikoucore/grim-rs/pull/18/commits/5c213ef2902f892726aadd7a95b31eae7165f56f)